### PR TITLE
feat: print generated SSH command from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ cargo install --git https://github.com/max-rh/sshelf
 ```sh
 sshelf                       # launch the TUI
 sshelf <host>                # connect straight to a saved host by name (skips the TUI)
+sshelf print-command <host>  # print the generated ssh command without connecting
 sshelf list                  # print saved hosts
 sshelf list <query>          # filter the list: fuzzy text and/or tag:NAME (e.g. tag:prod)
 sshelf --config FILE         # use a specific config file (also: $SSHELF_CONFIG)

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -7,6 +7,17 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
 
 ---
 
+## 2026-06-12 — CLI: print generated ssh command
+
+- Added `sshelf print-command <host>`: prints the same shell-quoted `ssh …` command as the
+  TUI `Ctrl-y` yank action, without connecting or updating frecency. Useful for scripts,
+  wrappers, and review before running a connection.
+- Fixed generated command strings to expand identity-file `~` before shell-quoting, so yanked
+  or printed commands remain copy-paste runnable.
+- Docs synced: README usage, `docs/ux.md` CLI table, and `docs/ssh-command.md` builder note.
+
+---
+
 ## 2026-06-07 — Release v0.2.0
 
 - Cut **v0.2.0**: ships the `sshelf <host>` direct-connect and `sshelf list <query>` filter

--- a/docs/ssh-command.md
+++ b/docs/ssh-command.md
@@ -22,9 +22,12 @@ ssh
 - `extra_args` is the escape hatch for anything the wizard doesn't model (`-X`, `-L …`,
   `-o …`). Split with `shlex::split` so quoted args survive.
 - Example: stored host `mike@10.25.25.25` with key `~/.ssh/infra-key` →
-  `ssh -i ~/.ssh/infra-key -o StrictHostKeyChecking=accept-new mike@10.25.25.25`.
+  `ssh -i /home/mike/.ssh/infra-key -o StrictHostKeyChecking=accept-new mike@10.25.25.25`
+  in the printed/yanked command (the exec path expands `~` internally as well).
 
-The same builder backs the `y` **yank** action (copy/print the exact command without connecting).
+The same builder backs the `Ctrl-y` **yank** action and `sshelf print-command <host>`
+(copy/print the exact command without connecting). For copy/paste safety, identity-file `~`
+is expanded before shell-quoting; quoted `~` would not expand in the user's shell.
 
 ## 2. Launch handoff (`exec`)
 

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -123,6 +123,7 @@ The CLI form supports `--dry-run` to preview. Never writes back to `~/.ssh/confi
 |---|---|
 | `sshelf` | Launch the interactive TUI. |
 | `sshelf <host>` | Connect straight to a saved host by **name or id**, skipping the TUI — same connect path as `Enter` (frecency recorded before the `exec`, secret auto-supplied). A miss suggests close names; a name that collides with a subcommand (`list`, `import`, …) is reached via the TUI instead. |
+| `sshelf print-command <host>` | Print the generated, shell-quoted `ssh …` command for a saved host by **name or id**, without connecting or changing frecency. This is the CLI equivalent of the TUI's `Ctrl-y` yank action. |
 | `sshelf list [query]` | List hosts. `query` filters with the TUI's syntax — fuzzy text and/or `tag:NAME` (e.g. `sshelf list tag:prod`, `sshelf list web`). |
 | `sshelf import [--dry-run]` | Read-only import from `~/.ssh/config`. |
 | `sshelf set-password <host>` | Store a password (read from stdin) for a host. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,11 @@ enum Command {
         /// Host name or id.
         host: String,
     },
+    /// Print the generated ssh command for a host without connecting.
+    PrintCommand {
+        /// Host name or id.
+        host: String,
+    },
     /// Print shell completions to stdout (for packaging / `source <(sshelf completions bash)`).
     Completions {
         /// Shell: bash, zsh, fish, elvish, or powershell.
@@ -103,6 +108,7 @@ fn main() -> Result<()> {
         }
         Some(Command::Import { dry_run }) => cmd_import(dry_run),
         Some(Command::SetPassword { host }) => cmd_set_password(&host),
+        Some(Command::PrintCommand { host }) => cmd_print_command(&host),
         Some(Command::Completions { shell }) => {
             clap_complete::generate(shell, &mut Cli::command(), "sshelf", &mut std::io::stdout());
             Ok(())
@@ -182,6 +188,18 @@ fn cmd_set_password(host_ref: &str) -> Result<()> {
     }
     secrets::store_password(&paths.vault_file(), &host.id, password)?;
     println!("stored password for \"{}\" ({})", host.name, host.id);
+    Ok(())
+}
+
+fn cmd_print_command(host_ref: &str) -> Result<()> {
+    let paths = Paths::resolve()?;
+    paths.ensure_dirs()?;
+    let _ = Config::ensure_default_file(&paths.config_file()); // best-effort
+    let cfg = Config::load(&paths.config_file())?;
+    let hosts = store::load_hosts(&cfg.hosts_path(&paths))?.hosts;
+    let host = resolve_host(&hosts, host_ref)
+        .with_context(|| format!("no host with name or id '{host_ref}'"))?;
+    println!("{}", ssh::command_string(host));
     Ok(())
 }
 
@@ -299,6 +317,15 @@ mod tests {
         match c.command {
             Some(Command::List { query }) => assert_eq!(query, vec!["tag:web", "staging"]),
             _ => panic!("expected the list subcommand"),
+        }
+    }
+
+    #[test]
+    fn print_command_captures_host() {
+        let c = Cli::try_parse_from(["sshelf", "print-command", "prod-web"]).unwrap();
+        match c.command {
+            Some(Command::PrintCommand { host }) => assert_eq!(host, "prod-web"),
+            _ => panic!("expected the print-command subcommand"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,8 @@ enum Command {
         host: String,
     },
     /// Print the generated ssh command for a host without connecting.
-    PrintCommand {
+    #[command(name = "print-command")]
+    Print {
         /// Host name or id.
         host: String,
     },
@@ -108,7 +109,7 @@ fn main() -> Result<()> {
         }
         Some(Command::Import { dry_run }) => cmd_import(dry_run),
         Some(Command::SetPassword { host }) => cmd_set_password(&host),
-        Some(Command::PrintCommand { host }) => cmd_print_command(&host),
+        Some(Command::Print { host }) => cmd_print_command(&host),
         Some(Command::Completions { shell }) => {
             clap_complete::generate(shell, &mut Cli::command(), "sshelf", &mut std::io::stdout());
             Ok(())
@@ -324,7 +325,7 @@ mod tests {
     fn print_command_captures_host() {
         let c = Cli::try_parse_from(["sshelf", "print-command", "prod-web"]).unwrap();
         match c.command {
-            Some(Command::PrintCommand { host }) => assert_eq!(host, "prod-web"),
+            Some(Command::Print { host }) => assert_eq!(host, "prod-web"),
             _ => panic!("expected the print-command subcommand"),
         }
     }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -24,8 +24,8 @@ fn expand_tilde(path: &str) -> String {
 
 /// Build the argument vector passed to `ssh` (excluding the program name).
 ///
-/// `expand`: expand identity-file `~` (required for exec, which has no shell). Pass `false`
-/// for a human-readable command (yank), where `~` is nicer and the user's shell expands it.
+/// `expand`: expand identity-file `~` so the generated argv stays valid without relying on a
+/// shell. `command_string` also expands before quoting, because quoted `~` is not shell-expanded.
 pub fn build_args(host: &Host, expand: bool) -> Vec<String> {
     let mut a: Vec<String> = Vec::new();
 
@@ -67,9 +67,9 @@ pub fn build_args(host: &Host, expand: bool) -> Vec<String> {
     a
 }
 
-/// A copy-pasteable `ssh …` command string (tilde preserved, args shell-quoted).
+/// A copy-pasteable `ssh …` command string (identity-file `~` expanded, args shell-quoted).
 pub fn command_string(host: &Host) -> String {
-    let args = build_args(host, false);
+    let args = build_args(host, true);
     let joined =
         shlex::try_join(args.iter().map(|s| s.as_str())).unwrap_or_else(|_| args.join(" "));
     format!("ssh {joined}")
@@ -199,10 +199,18 @@ mod tests {
 
     #[test]
     fn command_string_is_readable() {
+        // SAFETY: single-threaded test; sets HOME for the duration.
+        unsafe {
+            std::env::set_var("HOME", "/home/tester");
+        }
         let mut h = Host::new("a", "example.com");
         h.user = Some("root".into());
+        h.auth = AuthMethod::Key;
+        h.identity_files = vec!["~/.ssh/id key".into()];
         let s = command_string(&h);
         assert!(s.starts_with("ssh "));
+        assert!(s.contains("'/home/tester/.ssh/id key'"));
+        assert!(!s.contains("'~"));
         assert!(s.contains("root@example.com"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2.

Adds `sshelf print-command <host>` to print the same generated `ssh ...` command as the TUI `Ctrl-y` yank action, without connecting or updating frecency. This gives scripts/wrappers a non-interactive way to use sshelf as the host source of truth.

While smoke-testing the new command, I also noticed the existing command string path shell-quoted stored `~/.ssh/...` identity files, which prevents shell tilde expansion when copied. The command string now expands identity-file `~` before shell-quoting so both TUI-yanked and CLI-printed commands remain copy-paste runnable.

Docs are synced per the repo rule: README usage, `docs/ux.md`, `docs/ssh-command.md`, and `docs/progress.md`.

## Test plan

- [x] `cargo test`
- [x] `git diff --check`
- [x] smoke: `sshelf print-command prod-web --config <temp config>` prints a runnable SSH command
- [ ] `cargo fmt --check` (toolchain here lacks `cargo fmt` / `rustfmt`)
- [ ] `cargo clippy -- -D warnings` (toolchain here lacks `cargo clippy`)

Made with [Cursor](https://cursor.com)