### PR TITLE
Feat/sftp transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ sshelf print-command <host>  # print the generated ssh command without connectin
 sshelf list                  # print saved hosts
 sshelf list <query>          # filter the list: fuzzy text and/or tag:NAME (e.g. tag:prod)
 sshelf --config FILE         # use a specific config file (also: $SSHELF_CONFIG)
+sshelf --transfer-log FILE   # log transfer ssh/sftp commands + errors to FILE (debugging)
 sshelf import [--dry-run]    # read-only import from ~/.ssh/config
 echo "$PASS" | sshelf set-password <name>   # store a password (scriptable / headless)
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ an independent database, so it never risks corrupting a config shared with Ansib
 your editor, and adds things plain SSH config can't express as nicely:
 
 - **Atuin-style fuzzy launcher** — type to filter, `Enter` to connect.
+- **Dual-pane file transfer** (`Ctrl-t`) — a two-pane browser to copy files and folders to and
+  from a host over SFTP/SCP, with fuzzy search on both sides and live progress. It authenticates
+  once (reusing the host's keys/agent or stored password) and never touches `~/.ssh/config`.
 - **Guided add/edit form** — hostname, user, port, auth, jump hosts, tags, extra args.
 - **Auto-supplied passwords** for password-auth hosts (via `SSH_ASKPASS`; no `sshpass`, the
   secret never appears in `ps`). Stored in your OS keyring, or an encrypted vault.
@@ -84,8 +87,8 @@ echo "$PASS" | sshelf set-password <name>   # store a password (scriptable / hea
 ```
 
 **Keys:** type to filter · `tag:NAME` to filter by tag · `↑/↓` move · `Enter` connect ·
-`Ctrl-a` add · `Ctrl-e` edit · `Ctrl-d` delete · `Ctrl-y` yank the `ssh` command · `Ctrl-o`
-import · `F1` help · `F2` settings · `Esc`/`Ctrl-c` quit.
+`Ctrl-a` add · `Ctrl-e` edit · `Ctrl-d` delete · `Ctrl-y` yank the `ssh` command · `Ctrl-t`
+transfer files · `Ctrl-o` import · `F1` help · `F2` settings · `Esc`/`Ctrl-c` quit.
 
 In the **add/edit** form the Key field picks an identity: `←/→` cycles keys found in `~/.ssh`
 (including `.pem`), and `Enter` opens a file browser (type to fuzzy-filter) to choose a key

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,6 +5,19 @@ whenever you make a non-trivial design choice.
 
 ---
 
+### D-019 · File transfer rides an `ssh` ControlMaster; `sftp`/`scp` as subprocesses
+The dual-pane transfer screen moves files over the **system `sftp`/`scp` binaries**, not a Rust
+SSH library: every pure-Rust option either pulls C deps (libssh2) or forces `tokio` and can't
+reuse sshelf's `SSH_ASKPASS`/ProxyJump auth. To support password hosts without a fragile PTY,
+sshelf authenticates **once** by opening a backgrounded `ssh` **ControlMaster** (reusing
+`build_args` + the askpass env exactly as connect does); `sftp`/`scp` then ride it with only
+`-o ControlPath`, so there is no re-auth and no per-file prompt. A spike against a local sshd
+confirmed that (a) `SSH_ASKPASS` supplies the secret to open the master and (b) `sftp`/`scp`
+ride it for put/get and recursive copies. The ride commands deliberately omit `-p`/`-i`/`-J`
+(the master already carries them) — which also avoids the `ssh -p` vs `sftp`/`scp -P` port-flag
+clash. Rejected: `ssh2`/`wezterm-ssh` (C deps), `russh`/`openssh-sftp-client` (tokio + no askpass
+reuse), and a PTY password screen-scraper (brittle, locale/version-dependent).
+
 ### D-018 · Configurable hosts file in config; config file via flag/env only
 A `hosts_file` key in `config.toml` relocates the host DB (editable via the F2 settings screen,
 default under the config dir). The **config file's own** location can't be a config key

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -18,6 +18,12 @@ ride it for put/get and recursive copies. The ride commands deliberately omit `-
 clash. Rejected: `ssh2`/`wezterm-ssh` (C deps), `russh`/`openssh-sftp-client` (tokio + no askpass
 reuse), and a PTY password screen-scraper (brittle, locale/version-dependent).
 
+**Update (transfers use `sftp`, not `scp`):** listing and copying both run through `sftp`
+(`ls`/`get`/`put`). `scp` was dropped after a filename with spaces failed in testing — OpenSSH 9+
+`scp` speaks the SFTP protocol and takes the remote path *literally*, so shell-quoting it (needed
+by legacy `scp`) injects literal quotes. `sftp` quotes via its own command parser consistently
+across OpenSSH versions, so one quoting rule (`shell_quote`) is correct everywhere.
+
 ### D-018 · Configurable hosts file in config; config file via flag/env only
 A `hosts_file` key in `config.toml` relocates the host DB (editable via the F2 settings screen,
 default under the config dir). The **config file's own** location can't be a config key

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -7,6 +7,19 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
 
 ---
 
+## 2026-06-16 — Transfer: use `sftp` (not `scp`) for the copy itself
+
+- Bug found in local testing: transferring a filename with **spaces** failed
+  (`scp: failed to upload … to '/…`). OpenSSH 9+ `scp` speaks the SFTP protocol and takes the
+  remote path literally, so the shell-quoting legacy `scp` needed became *literal quotes* in the
+  name. Plain names slipped through because they aren't quoted.
+- Fixed by running transfers through **`sftp` `get`/`put`** over the same master used for
+  listing — `sftp` quotes via its own command parser consistently across OpenSSH versions, so
+  the version-dependent `scp` quoting trap is gone. Removed `scp_args`/`remote_spec`; added a
+  `transfer_batch` unit test and a spaces regression to the e2e test.
+
+---
+
 ## 2026-06-16 — Transfer screen: transport core + worker
 
 - Started the dual-pane SFTP/SCP **transfer screen**. Settled the transport (see `decisions.md`

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -7,6 +7,17 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
 
 ---
 
+## 2026-06-16 — Transfer: `--transfer-log` diagnostics
+
+- Added a transfer debug log: `sshelf --transfer-log <FILE>` (or `$SSHELF_TRANSFER_LOG`) appends
+  every `ssh`/`sftp` command the worker runs plus its full stderr to `FILE`, so a failed transfer
+  can be inspected after the fact (the status line still shows the one-line cause). No secrets are
+  logged — the password reaches `ssh` via `SSH_ASKPASS`, never argv. The e2e test asserts the log
+  captures the master + `get`/`put` commands. Docs: README, `ux.md` (CLI table + transfer
+  section), `security.md`.
+
+---
+
 ## 2026-06-16 — Transfer: use `sftp` (not `scp`) for the copy itself
 
 - Bug found in local testing: transferring a filename with **spaces** failed

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -22,7 +22,14 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
   dirs by parsing `sftp ls -l`, runs `scp` transfers with throttled progress + mid-flight
   cancel, and tears the master + control socket down on stop via RAII. 101 tests; clippy + fmt
   clean. No UI yet; the live end-to-end run lands with the engine milestone.
-- Next: generalize the file browser into a dual-pane `Pane`/`DirSource`, then the transfer UI.
+- Added `transfer/pane.rs`: one side's state — fuzzy filter + selection + navigation reused
+  from the key-picker browser, a synthetic `..` entry, `ls -F`-style dir/`@`-symlink labels with
+  control-char stripping, and a local-directory reader. Kept source-agnostic rather than behind
+  a `DirSource` trait (a synchronous remote `list()` would block the very UI loop the worker
+  keeps responsive); the screen feeds local entries via `std::fs` and remote ones via the worker.
+  109 tests; clippy + fmt clean.
+- Next: the `ui/transfer.rs` render + the transfer screen wiring (Ctrl-t entry, pane focus,
+  draining the worker's events each tick).
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -7,6 +7,20 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
 
 ---
 
+## 2026-06-16 — Transfer screen: transport core + validated approach
+
+- Started the dual-pane SFTP/SCP **transfer screen**. Settled the transport (see `decisions.md`
+  D-019): move files over the system `sftp`/`scp` riding a single `ssh` **ControlMaster**, so
+  keys/agent/ProxyJump and the stored keyring/vault secret are reused unchanged and password
+  hosts work with no PTY. A spike against a local sshd confirmed `SSH_ASKPASS` opens the master
+  and that `sftp`/`scp` ride it (put/get + recursive).
+- Landed the tested core in `src/transfer/mod.rs`: the master/`sftp`/`scp` argv builders, the
+  `user@host` target + shell-quoted remote-path spec, the worker↔UI message protocol, and
+  progress math. 96 tests; clippy + fmt clean. No UI yet.
+- Next: the worker thread + ControlMaster lifecycle, then the dual-pane browse/transfer UI.
+
+---
+
 ## 2026-06-12 — CLI: print generated ssh command
 
 - Added `sshelf print-command <host>`: prints the same shell-quoted `ssh …` command as the

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -7,7 +7,7 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
 
 ---
 
-## 2026-06-16 — Transfer screen: transport core + validated approach
+## 2026-06-16 — Transfer screen: transport core + worker
 
 - Started the dual-pane SFTP/SCP **transfer screen**. Settled the transport (see `decisions.md`
   D-019): move files over the system `sftp`/`scp` riding a single `ssh` **ControlMaster**, so
@@ -16,8 +16,13 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
   and that `sftp`/`scp` ride it (put/get + recursive).
 - Landed the tested core in `src/transfer/mod.rs`: the master/`sftp`/`scp` argv builders, the
   `user@host` target + shell-quoted remote-path spec, the worker↔UI message protocol, and
-  progress math. 96 tests; clippy + fmt clean. No UI yet.
-- Next: the worker thread + ControlMaster lifecycle, then the dual-pane browse/transfer UI.
+  progress math.
+- Added the worker thread + ControlMaster lifecycle (`src/transfer/worker.rs`): it opens the
+  master (reusing `ssh::configure_askpass`, now `pub(crate)`), polls it ready, lists remote
+  dirs by parsing `sftp ls -l`, runs `scp` transfers with throttled progress + mid-flight
+  cancel, and tears the master + control socket down on stop via RAII. 101 tests; clippy + fmt
+  clean. No UI yet; the live end-to-end run lands with the engine milestone.
+- Next: generalize the file browser into a dual-pane `Pane`/`DirSource`, then the transfer UI.
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -28,8 +28,27 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
   a `DirSource` trait (a synchronous remote `list()` would block the very UI loop the worker
   keeps responsive); the screen feeds local entries via `std::fs` and remote ones via the worker.
   109 tests; clippy + fmt clean.
-- Next: the `ui/transfer.rs` render + the transfer screen wiring (Ctrl-t entry, pane focus,
-  draining the worker's events each tick).
+- Wired the screen end to end: `transfer/screen.rs` (two panes over one session — local nav is
+  synchronous, remote nav requests via the worker, events drained each tick) and `ui/transfer.rs`
+  (two panes, progress/status line, hint bar; `TestBackend`-snapshotted via a borrowed view, and
+  a "terminal too small" clamp). `Ctrl-t` on the list opens it (`Outcome::Transfer`); the event
+  loop polls + drains while it's open and tears the worker down on close (RAII). Keys: `Tab`
+  switch · `→`/`Enter` open · `Ctrl-s` send file/folder · `←`/`Backspace` up · `Esc` cancel/
+  clear/close. Docs: `ux.md` transfer section + keybinding. 113 tests; clippy + fmt clean.
+- Validated the transport end to end against a throwaway localhost `sshd` (`transfer/e2e.rs`,
+  `#[ignore]`d — run with `cargo test -- --ignored`): the master opens, `sftp` `pwd`/`ls`
+  parse, single-file download + upload (contents verified), and recursive directory download
+  all pass.
+- Robustness + docs pass: a same-named destination is **skipped** rather than clobbered;
+  README gains a feature bullet + the `^t` key, `security.md` covers the transfer network path,
+  and `structure.md` maps the new modules. Added master-command tests for ProxyJump + password
+  hosts — the auth itself reuses `build_args`/`configure_askpass` (already tested), and the M0
+  spike proved `SSH_ASKPASS` opens the master, so a password *target* and key/agent jumps work;
+  a fully automated password-auth transfer E2E needs a PAM/Docker sshd (the rootless test server
+  is key-auth only) and is a CI-with-Docker follow-up.
+- The transfer screen is **functionally complete**: dual-pane browse + fuzzy on both sides,
+  single-file and recursive folder transfer in both directions over one multiplexed master,
+  live progress, cancel, and overwrite-skip. 116 unit tests + 1 e2e; clippy + fmt clean.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -63,12 +63,12 @@ hostile hosts.
 - **`StrictHostKeyChecking=accept-new`** trusts a *new* host's key on first connect but still
   hard-fails if a *known* host's key changes (MITM protection retained).
 - **Network:** `sshelf` makes no network connections of its own and has no telemetry; it only
-  ever launches the OpenSSH tools — `ssh` to connect, and `ssh`/`sftp`/`scp` for the file-transfer
+  ever launches the OpenSSH tools — `ssh` to connect, and `ssh`/`sftp` for the file-transfer
   screen. Transfers authenticate exactly as connect does (keys/agent, or the stored secret via
-  `SSH_ASKPASS`) by opening **one** multiplexed `ssh` ControlMaster and running `sftp`/`scp` over
-  it — so no extra secret handling, and the secret still never reaches argv. Remote paths are
-  shell-quoted before they reach `sftp`/`scp`, control characters are stripped from displayed
-  names, and `StrictHostKeyChecking=accept-new` applies there too.
+  `SSH_ASKPASS`) by opening **one** multiplexed `ssh` ControlMaster and running `sftp` over it —
+  so no extra secret handling, and the secret still never reaches argv. Remote paths are quoted
+  for `sftp`'s parser, control characters are stripped from displayed names, and
+  `StrictHostKeyChecking=accept-new` applies there too.
 
 ## Reporting
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -68,7 +68,9 @@ hostile hosts.
   `SSH_ASKPASS`) by opening **one** multiplexed `ssh` ControlMaster and running `sftp` over it —
   so no extra secret handling, and the secret still never reaches argv. Remote paths are quoted
   for `sftp`'s parser, control characters are stripped from displayed names, and
-  `StrictHostKeyChecking=accept-new` applies there too.
+  `StrictHostKeyChecking=accept-new` applies there too. The optional transfer log
+  (`--transfer-log` / `$SSHELF_TRANSFER_LOG`) records the `ssh`/`sftp` commands and their stderr
+  for troubleshooting — it contains **no secrets** (same reason: the password goes via askpass).
 
 ## Reporting
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -63,7 +63,12 @@ hostile hosts.
 - **`StrictHostKeyChecking=accept-new`** trusts a *new* host's key on first connect but still
   hard-fails if a *known* host's key changes (MITM protection retained).
 - **Network:** `sshelf` makes no network connections of its own and has no telemetry; it only
-  ever launches `ssh`.
+  ever launches the OpenSSH tools — `ssh` to connect, and `ssh`/`sftp`/`scp` for the file-transfer
+  screen. Transfers authenticate exactly as connect does (keys/agent, or the stored secret via
+  `SSH_ASKPASS`) by opening **one** multiplexed `ssh` ControlMaster and running `sftp`/`scp` over
+  it — so no extra secret handling, and the secret still never reaches argv. Remote paths are
+  shell-quoted before they reach `sftp`/`scp`, control characters are stripped from displayed
+  names, and `StrictHostKeyChecking=accept-new` applies there too.
 
 ## Reporting
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -37,8 +37,8 @@ ssh-tui/                 (crate/binary name: `sshelf`)
 | `import.rs` | `ssh2-config` parse of `~/.ssh/config` → `Host` mapping; warn on unsupported `Match`/`Include`. |
 | `paths.rs` | `etcetera` path resolution (config/data dirs); file paths; dir/file perms (`0700`/`0600`). |
 | `config.rs` | Preferences: `decay_rate`, `default_sort`, `accent` color; writes a commented default on first run. |
-| `transfer/mod.rs` | File-transfer core: `ssh`-ControlMaster + `sftp`/`scp` argv builders, the worker↔UI message protocol (`WorkerCmd`/`WorkerEvent`), and progress math. |
-| `transfer/worker.rs` | Background worker thread: owns the ControlMaster (open/readiness/teardown), lists remote dirs (`sftp ls -l`), runs `scp` transfers with progress + cancel. |
+| `transfer/mod.rs` | File-transfer core: `ssh`-ControlMaster + `sftp` argv builders, the worker↔UI message protocol (`WorkerCmd`/`WorkerEvent`), and progress math. |
+| `transfer/worker.rs` | Background worker thread: owns the ControlMaster (open/readiness/teardown), lists remote dirs (`sftp ls -l`), runs `sftp` `get`/`put` transfers with progress + cancel. |
 | `transfer/pane.rs` | One side's browsing state (fuzzy filter + selection + nav, reusing `search`); `read_local_dir` for the local side; `RemoteEntry`→`PaneEntry`. |
 | `transfer/screen.rs` | The dual-pane `TransferScreen`: two panes over one session, key handling, draining worker events. |
 | `ui/list.rs` | Host list rendering + match highlighting + selection. |

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -3,7 +3,7 @@
 > Keep this in sync with the actual tree (the docs-in-sync rule).
 >
 > **All modules present:** `main`, `app`, `askpass`, `config`, `import`, `model`, `paths`,
-> `search`, `secrets`, `ssh`, `state`, `store`, `vault`,
+> `search`, `secrets`, `ssh`, `state`, `store`, `transfer`, `vault`,
 > `ui/{mod,list,help,widgets,wizard,browse,settings}`.
 > (`error.rs` was removed — the codebase uses `anyhow` throughout.)
 
@@ -37,6 +37,7 @@ ssh-tui/                 (crate/binary name: `sshelf`)
 | `import.rs` | `ssh2-config` parse of `~/.ssh/config` → `Host` mapping; warn on unsupported `Match`/`Include`. |
 | `paths.rs` | `etcetera` path resolution (config/data dirs); file paths; dir/file perms (`0700`/`0600`). |
 | `config.rs` | Preferences: `decay_rate`, `default_sort`, `accent` color; writes a commented default on first run. |
+| `transfer/mod.rs` | File-transfer core: `ssh`-ControlMaster + `sftp`/`scp` argv builders, the worker↔UI message protocol, and progress math. (Worker thread + dual-pane UI land with the transfer screen.) |
 | `ui/list.rs` | Host list rendering + match highlighting + selection. |
 | `ui/wizard.rs` | Auth-aware add/edit form: fields, validation, key picker, opens the file browser. |
 | `ui/browse.rs` | File-browser modal (fuzzy-filtered) for picking a key file anywhere on disk. |

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -3,8 +3,8 @@
 > Keep this in sync with the actual tree (the docs-in-sync rule).
 >
 > **All modules present:** `main`, `app`, `askpass`, `config`, `import`, `model`, `paths`,
-> `search`, `secrets`, `ssh`, `state`, `store`, `transfer`, `vault`,
-> `ui/{mod,list,help,widgets,wizard,browse,settings}`.
+> `search`, `secrets`, `ssh`, `state`, `store`, `transfer/{mod,worker,pane,screen}`, `vault`,
+> `ui/{mod,list,help,widgets,wizard,browse,settings,transfer}`.
 > (`error.rs` was removed — the codebase uses `anyhow` throughout.)
 
 ## Repository
@@ -37,8 +37,12 @@ ssh-tui/                 (crate/binary name: `sshelf`)
 | `import.rs` | `ssh2-config` parse of `~/.ssh/config` → `Host` mapping; warn on unsupported `Match`/`Include`. |
 | `paths.rs` | `etcetera` path resolution (config/data dirs); file paths; dir/file perms (`0700`/`0600`). |
 | `config.rs` | Preferences: `decay_rate`, `default_sort`, `accent` color; writes a commented default on first run. |
-| `transfer/mod.rs` | File-transfer core: `ssh`-ControlMaster + `sftp`/`scp` argv builders, the worker↔UI message protocol, and progress math. (Worker thread + dual-pane UI land with the transfer screen.) |
+| `transfer/mod.rs` | File-transfer core: `ssh`-ControlMaster + `sftp`/`scp` argv builders, the worker↔UI message protocol (`WorkerCmd`/`WorkerEvent`), and progress math. |
+| `transfer/worker.rs` | Background worker thread: owns the ControlMaster (open/readiness/teardown), lists remote dirs (`sftp ls -l`), runs `scp` transfers with progress + cancel. |
+| `transfer/pane.rs` | One side's browsing state (fuzzy filter + selection + nav, reusing `search`); `read_local_dir` for the local side; `RemoteEntry`→`PaneEntry`. |
+| `transfer/screen.rs` | The dual-pane `TransferScreen`: two panes over one session, key handling, draining worker events. |
 | `ui/list.rs` | Host list rendering + match highlighting + selection. |
+| `ui/transfer.rs` | Renders the transfer screen (two panes + progress/status + hint bar) from a borrowed view. |
 | `ui/wizard.rs` | Auth-aware add/edit form: fields, validation, key picker, opens the file browser. |
 | `ui/browse.rs` | File-browser modal (fuzzy-filtered) for picking a key file anywhere on disk. |
 | `ui/settings.rs` | Settings screen (F2): config-file display + editable hosts-file location. |

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -123,8 +123,8 @@ The CLI form supports `--dry-run` to preview. Never writes back to `~/.ssh/confi
 `Ctrl-t` on a host opens a **dual-pane transfer screen**: local files on the left, the host's
 files on the right. sshelf authenticates **once** by opening an `ssh` ControlMaster that reuses
 the host's auth (keys/agent/ProxyJump, or the stored keyring/vault secret via `SSH_ASKPASS`),
-then runs `sftp`/`scp` over it. Remote listing and transfers run on a background thread, so the
-UI stays responsive on slow links.
+then runs `sftp` (`ls`/`get`/`put`) over it. Remote listing and transfers run on a background
+thread, so the UI stays responsive on slow links.
 
 Both panes fuzzy-filter as you type:
 

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -45,6 +45,7 @@ list. Actions therefore use **Ctrl** (or function keys) to avoid being typed int
 | `Ctrl-e` | edit selected host — M4 |
 | `Ctrl-d` | delete selected host (confirm) — M4 |
 | `Ctrl-y` | yank — copy/print the generated `ssh` command without connecting — M3 |
+| `Ctrl-t` | open the dual-pane **file-transfer** screen for the selected host |
 | `Ctrl-o` | import from `~/.ssh/config` (read-only) — M7 |
 | `F1` | help overlay |
 | `F2` | settings (config & hosts-file locations) |
@@ -116,6 +117,35 @@ Parses `~/.ssh/config` **read-only** via `ssh2-config` and adds every host whose
 already present, warning about unsupported `Match` / `Include` / `ProxyJump`. v1 imports all
 new hosts at once (no per-host selection screen) — curate afterwards with `Ctrl-e` / `Ctrl-d`.
 The CLI form supports `--dry-run` to preview. Never writes back to `~/.ssh/config`.
+
+## File transfer (`Ctrl-t`)
+
+`Ctrl-t` on a host opens a **dual-pane transfer screen**: local files on the left, the host's
+files on the right. sshelf authenticates **once** by opening an `ssh` ControlMaster that reuses
+the host's auth (keys/agent/ProxyJump, or the stored keyring/vault secret via `SSH_ASKPASS`),
+then runs `sftp`/`scp` over it. Remote listing and transfers run on a background thread, so the
+UI stays responsive on slow links.
+
+Both panes fuzzy-filter as you type:
+
+| Key | Action |
+|---|---|
+| _type_ | filter the focused pane |
+| `Tab` | switch the focused pane (local ↔ remote) |
+| `↑` / `↓`, `Ctrl-p` / `Ctrl-n` | move the selection |
+| `→` / `Enter` | open the selected directory (or send a file) |
+| `Ctrl-s` | **send** the selected file or folder (recursive) into the *other* pane's directory |
+| `←` | go up a directory |
+| `Backspace` | edit the filter, or go up when it's empty |
+| `Esc` | cancel a running transfer, else clear the filter, else close the screen |
+
+A progress bar shows bytes and percent for single-file downloads; folder and upload transfers
+show as in-flight (cancelable with `Esc`). Directories are marked `name/` and symlinks `name@`;
+symlinks are skipped in this version. Filenames are shell-quoted and control characters stripped
+from display. The connection uses `StrictHostKeyChecking=accept-new`, like connect — so a
+first-time host key is trusted on use (see [`security.md`](security.md)). Only one transfer runs
+at a time in v1, and a same-named file or folder already present in the destination is **skipped**
+(with a message) rather than overwritten.
 
 ## CLI (outside the TUI)
 

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -147,6 +147,11 @@ first-time host key is trusted on use (see [`security.md`](security.md)). Only o
 at a time in v1, and a same-named file or folder already present in the destination is **skipped**
 (with a message) rather than overwritten.
 
+On failure the status line shows the underlying `sftp` error. For more detail, run with
+`sshelf --transfer-log <FILE>` (or `$SSHELF_TRANSFER_LOG=<FILE>`): the worker appends every
+`ssh`/`sftp` command and its full stderr to that file. The log holds no secrets — the password
+reaches `ssh` via `SSH_ASKPASS`, never the command line.
+
 ## CLI (outside the TUI)
 
 | Command | What it does |
@@ -159,6 +164,7 @@ at a time in v1, and a same-named file or folder already present in the destinat
 | `sshelf set-password <host>` | Store a password (read from stdin) for a host. |
 | `sshelf completions <shell>` · `sshelf man` | Emit shell completions / the man page. |
 | `--config FILE` (global) | Use a specific config file (also `$SSHELF_CONFIG`). |
+| `--transfer-log FILE` (global) | Append transfer-screen diagnostics — the `ssh`/`sftp` commands and their errors (no secrets) — to `FILE`. Also `$SSHELF_TRANSFER_LOG`. |
 
 ## Confirmations & overlays
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@
 //! once the TUI is torn down (so ssh inherits a clean TTY).
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::Result;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -21,6 +22,7 @@ use crate::secrets;
 use crate::ssh;
 use crate::state::FrecencyState;
 use crate::store;
+use crate::transfer::{self, TransferOutcome};
 use crate::ui;
 use crate::ui::settings::{Settings, SettingsOutcome};
 use crate::ui::wizard::{Wizard, WizardOutcome};
@@ -45,6 +47,8 @@ pub enum Outcome {
     Quit,
     Connect(usize),
     Yank(usize),
+    /// Open the transfer screen for this host (the loop spawns the worker after key handling).
+    Transfer(usize),
 }
 
 pub struct App {
@@ -64,6 +68,8 @@ pub struct App {
     pub wizard: Option<Wizard>,
     pub confirm: Option<ConfirmDelete>,
     pub settings: Option<Settings>,
+    /// The dual-pane file-transfer screen, when open.
+    pub transfer: Option<transfer::TransferScreen>,
     /// Transient status line (cleared on next keypress).
     pub status: Option<String>,
     pub should_quit: bool,
@@ -87,6 +93,7 @@ impl App {
             wizard: None,
             confirm: None,
             settings: None,
+            transfer: None,
             status: None,
             should_quit: false,
             pending_connect: None,
@@ -128,6 +135,13 @@ impl App {
 
     pub fn on_key(&mut self, key: KeyEvent) -> Outcome {
         if key.kind != KeyEventKind::Press {
+            return Outcome::Continue;
+        }
+        if let Some(screen) = self.transfer.as_mut() {
+            // Dropping the screen closes the worker (master + socket torn down) via its RAII.
+            if let TransferOutcome::Close = screen.on_key(key) {
+                self.transfer = None;
+            }
             return Outcome::Continue;
         }
         if self.confirm.is_some() {
@@ -172,6 +186,11 @@ impl App {
             (KeyCode::Char('y'), true) => {
                 if let Some(i) = self.current() {
                     return Outcome::Yank(i);
+                }
+            }
+            (KeyCode::Char('t'), true) => {
+                if let Some(i) = self.current() {
+                    return Outcome::Transfer(i);
                 }
             }
             (KeyCode::Char('a'), true) => self.wizard = Some(Wizard::new_add()),
@@ -383,6 +402,25 @@ impl App {
         }
     }
 
+    /// Spawn the transfer worker for `idx` and open the dual-pane screen. Mirrors connect: the
+    /// event loop calls this so the side effects (a worker thread, a secrets lookup) stay out
+    /// of the testable `on_key`.
+    fn open_transfer(&mut self, idx: usize) {
+        let host = self.hosts[idx].clone();
+        let has_secret = secrets::get_password(&self.paths.vault_file(), &host.id)
+            .ok()
+            .flatten()
+            .is_some();
+        let start = std::env::current_dir()
+            .ok()
+            .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
+            .unwrap_or_else(|| PathBuf::from("/"));
+        match transfer::TransferScreen::open(&host, has_secret, start) {
+            Ok(screen) => self.transfer = Some(screen),
+            Err(e) => self.set_status(format!("could not start transfer: {e}")),
+        }
+    }
+
     fn move_down(&mut self) {
         if !self.order.is_empty() && self.selected + 1 < self.order.len() {
             self.selected += 1;
@@ -432,26 +470,43 @@ pub fn run() -> Result<()> {
 fn event_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Result<()> {
     while !app.should_quit {
         terminal.draw(|frame| ui::render(frame, app))?;
-        if let Event::Key(key) = event::read()? {
-            match app.on_key(key) {
-                Outcome::Quit => app.should_quit = true,
-                Outcome::Connect(idx) => {
-                    app.pending_connect = Some(idx);
-                    app.should_quit = true;
-                }
-                Outcome::Yank(idx) => {
-                    let cmd = ssh::command_string(&app.hosts[idx]);
-                    if ssh::copy_to_clipboard(&cmd) {
-                        app.set_status(format!("copied: {cmd}"));
-                    } else {
-                        app.set_status(cmd);
-                    }
-                }
-                Outcome::Continue => {}
+        if app.transfer.is_some() {
+            // The transfer screen is live: poll so worker events and progress animate without a
+            // keypress, then drain whatever the worker produced this tick.
+            if event::poll(Duration::from_millis(100))?
+                && let Event::Key(key) = event::read()?
+            {
+                dispatch(app, key);
             }
+            if let Some(screen) = app.transfer.as_mut() {
+                screen.drain_events();
+            }
+        } else if let Event::Key(key) = event::read()? {
+            dispatch(app, key);
         }
     }
     Ok(())
+}
+
+/// Handle one key by routing the resulting outcome (shared by the blocking and polling paths).
+fn dispatch(app: &mut App, key: KeyEvent) {
+    match app.on_key(key) {
+        Outcome::Quit => app.should_quit = true,
+        Outcome::Connect(idx) => {
+            app.pending_connect = Some(idx);
+            app.should_quit = true;
+        }
+        Outcome::Yank(idx) => {
+            let cmd = ssh::command_string(&app.hosts[idx]);
+            if ssh::copy_to_clipboard(&cmd) {
+                app.set_status(format!("copied: {cmd}"));
+            } else {
+                app.set_status(cmd);
+            }
+        }
+        Outcome::Transfer(idx) => app.open_transfer(idx),
+        Outcome::Continue => {}
+    }
 }
 
 #[cfg(test)]
@@ -525,6 +580,16 @@ mod tests {
         assert_eq!(
             app.on_key(ctrl(KeyCode::Char('y'))),
             Outcome::Yank(expected)
+        );
+    }
+
+    #[test]
+    fn ctrl_t_opens_transfer_for_selected() {
+        let mut app = test_app();
+        let expected = app.order[app.selected];
+        assert_eq!(
+            app.on_key(ctrl(KeyCode::Char('t'))),
+            Outcome::Transfer(expected)
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,10 @@ struct Cli {
     /// Use a specific config file (default: ~/.config/sshelf/config.toml).
     #[arg(long, global = true, value_name = "FILE")]
     config: Option<PathBuf>,
+    /// Append transfer-screen diagnostics (the ssh/sftp commands + their errors; no secrets)
+    /// to FILE. Also settable via $SSHELF_TRANSFER_LOG.
+    #[arg(long, global = true, value_name = "FILE")]
+    transfer_log: Option<PathBuf>,
     /// Connect directly to a saved host by name (skips the TUI). With no host and no
     /// subcommand, sshelf launches the interactive TUI.
     #[arg(value_name = "HOST")]
@@ -100,6 +104,12 @@ fn main() -> Result<()> {
         // SAFETY: set once at startup, before any threads are spawned.
         unsafe {
             std::env::set_var(CONFIG_ENV, path);
+        }
+    }
+    if let Some(path) = &cli.transfer_log {
+        // SAFETY: set once at startup, before any threads are spawned.
+        unsafe {
+            std::env::set_var(transfer::LOG_ENV, path);
         }
     }
     match cli.command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod secrets;
 mod ssh;
 mod state;
 mod store;
+mod transfer;
 mod ui;
 mod vault;
 

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -105,7 +105,9 @@ pub fn exec_connect(host: &Host, wire_askpass: bool) -> anyhow::Error {
 /// Wire our own binary as the `SSH_ASKPASS` helper so the stored secret (a login password OR
 /// a key passphrase) is supplied automatically. Only when `wire_askpass` is set (a secret
 /// exists); otherwise clear any inherited askpass so ssh prompts / uses the agent normally.
-fn configure_askpass(cmd: &mut std::process::Command, host: &Host, wire_askpass: bool) {
+///
+/// Reused by the transfer worker to authenticate the ControlMaster exactly as connect does.
+pub(crate) fn configure_askpass(cmd: &mut std::process::Command, host: &Host, wire_askpass: bool) {
     cmd.env_remove("SSH_ASKPASS")
         .env_remove("SSH_ASKPASS_REQUIRE");
     if !wire_askpass {

--- a/src/transfer/e2e.rs
+++ b/src/transfer/e2e.rs
@@ -1,0 +1,256 @@
+//! End-to-end transfer tests against a throwaway, rootless `sshd` on localhost.
+//!
+//! These spawn a real `sshd` plus `ssh`/`sftp`/`scp`, so they are `#[ignore]`d — run them with
+//! `cargo test -- --ignored` on a machine with OpenSSH installed. They drive the worker exactly
+//! as the transfer screen does (open the master, list a remote directory, copy files both ways,
+//! recursively), and confirm the ControlMaster + `sftp`/`scp` transport works against a real
+//! server. The unit tests cover the pure pieces (argv builders, `ls -l` parsing, progress math);
+//! this is the integration layer the M0 spike proved by hand.
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::mpsc::Receiver;
+use std::time::{Duration, Instant};
+
+use crate::model::{AuthMethod, Host};
+
+use super::worker::TransferSession;
+use super::{Direction, TransferJob, WorkerCmd, WorkerEvent};
+
+static NEXT_PORT: AtomicU16 = AtomicU16::new(47137);
+
+/// A running throwaway `sshd`; killed and cleaned up on drop.
+struct Sshd {
+    child: Child,
+    dir: PathBuf,
+    port: u16,
+    key: PathBuf,
+    known_hosts: PathBuf,
+}
+
+impl Drop for Sshd {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn sftp_server() -> Option<&'static str> {
+    [
+        "/usr/libexec/sftp-server",     // macOS
+        "/usr/lib/openssh/sftp-server", // Debian/Ubuntu
+        "/usr/lib/ssh/sftp-server",     // Arch
+    ]
+    .into_iter()
+    .find(|p| Path::new(p).exists())
+}
+
+fn keygen(path: &Path) {
+    let ok = Command::new("ssh-keygen")
+        .args(["-q", "-t", "ed25519", "-N", ""])
+        .arg("-f")
+        .arg(path)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    assert!(ok, "ssh-keygen failed");
+}
+
+/// Start a key-auth `sshd` on a free localhost port, or `None` if the host lacks the binaries.
+fn start_sshd() -> Option<Sshd> {
+    let sftp = sftp_server()?;
+    if !Path::new("/usr/sbin/sshd").exists() {
+        return None;
+    }
+    let dir = std::env::temp_dir().join(format!("sshelf-e2e-{}", ulid::Ulid::new()));
+    std::fs::create_dir_all(&dir).ok()?;
+    let hostkey = dir.join("hostkey");
+    let key = dir.join("id");
+    keygen(&hostkey);
+    keygen(&key);
+    let authorized = dir.join("authorized_keys");
+    std::fs::copy(dir.join("id.pub"), &authorized).ok()?;
+
+    let port = NEXT_PORT.fetch_add(1, Ordering::Relaxed);
+    let cfg = dir.join("sshd_config");
+    std::fs::write(
+        &cfg,
+        format!(
+            "Port {port}\n\
+             ListenAddress 127.0.0.1\n\
+             HostKey {hostkey}\n\
+             PidFile {pid}\n\
+             AuthorizedKeysFile {authorized}\n\
+             PasswordAuthentication no\n\
+             UsePAM no\n\
+             StrictModes no\n\
+             Subsystem sftp {sftp}\n",
+            hostkey = hostkey.display(),
+            pid = dir.join("pid").display(),
+            authorized = authorized.display(),
+        ),
+    )
+    .ok()?;
+
+    let child = Command::new("/usr/sbin/sshd")
+        .arg("-f")
+        .arg(&cfg)
+        .args(["-D", "-e"])
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let sshd = Sshd {
+        child,
+        dir: dir.clone(),
+        port,
+        key,
+        known_hosts: dir.join("known_hosts"),
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return Some(sshd);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    None // `sshd` dropped here → killed + cleaned up
+}
+
+/// A `Host` pointing at the throwaway server (key auth; test-only ssh options via `extra_args`).
+fn host_for(sshd: &Sshd) -> Host {
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "root".into());
+    let mut h = Host::new("e2e", "127.0.0.1");
+    h.user = Some(user);
+    h.port = Some(sshd.port);
+    h.auth = AuthMethod::Key;
+    h.identity_files = vec![sshd.key.to_string_lossy().into_owned()];
+    h.extra_args = Some(format!(
+        "-o UserKnownHostsFile={} -o IdentitiesOnly=yes",
+        sshd.known_hosts.display()
+    ));
+    h
+}
+
+/// Block (up to 15s) for the next event matching `pred`, returning it.
+fn recv_until(rx: &Receiver<WorkerEvent>, pred: impl Fn(&WorkerEvent) -> bool) -> WorkerEvent {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .expect("timed out waiting for a worker event");
+        let event = rx
+            .recv_timeout(remaining)
+            .expect("worker channel closed or timed out");
+        if pred(&event) {
+            return event;
+        }
+    }
+}
+
+#[test]
+#[ignore = "spawns a real sshd + ssh/sftp/scp; run with `cargo test -- --ignored`"]
+fn lists_and_transfers_both_directions() {
+    let Some(sshd) = start_sshd() else {
+        eprintln!("skipping e2e: no usable sshd / sftp-server on this host");
+        return;
+    };
+
+    // Remote tree (remote == localhost): a dir with a file and a nested subdir.
+    let remote = sshd.dir.join("remote");
+    std::fs::create_dir_all(remote.join("sub")).unwrap();
+    std::fs::write(remote.join("hello.txt"), b"hello from remote").unwrap();
+    std::fs::write(remote.join("sub/inner.txt"), b"deep").unwrap();
+
+    let (session, events) = TransferSession::spawn(host_for(&sshd), false).unwrap();
+
+    // The master opens and reports a working directory.
+    let home = match recv_until(&events, |e| matches!(e, WorkerEvent::Ready(_))) {
+        WorkerEvent::Ready(Ok(home)) => home,
+        WorkerEvent::Ready(Err(e)) => panic!("master failed to open: {e}"),
+        _ => unreachable!(),
+    };
+    // Confirms `sftp pwd` parsing — a parse failure would fall back to "/".
+    assert!(home.is_absolute());
+    assert_ne!(
+        home,
+        Path::new("/"),
+        "remote home fell back to / (pwd parse failed?)"
+    );
+
+    // List the remote directory.
+    session.send(WorkerCmd::ListRemote(remote.clone()));
+    let WorkerEvent::Listing { entries, .. } =
+        recv_until(&events, |e| matches!(e, WorkerEvent::Listing { .. }))
+    else {
+        unreachable!()
+    };
+    assert!(entries.iter().any(|e| e.name == "hello.txt" && !e.is_dir));
+    assert!(entries.iter().any(|e| e.name == "sub" && e.is_dir));
+
+    // Download a single file.
+    let dl = sshd.dir.join("download");
+    std::fs::create_dir_all(&dl).unwrap();
+    session.send(WorkerCmd::Transfer(TransferJob {
+        direction: Direction::Download,
+        src: remote.join("hello.txt"),
+        dest_dir: dl.clone(),
+        recursive: false,
+        size_hint: 0,
+    }));
+    expect_done(&events, "download");
+    assert_eq!(
+        std::fs::read(dl.join("hello.txt")).unwrap(),
+        b"hello from remote"
+    );
+
+    // Upload a single file.
+    let up = sshd.dir.join("upload.txt");
+    std::fs::write(&up, b"hello from local").unwrap();
+    let remote_dst = sshd.dir.join("remote-dst");
+    std::fs::create_dir_all(&remote_dst).unwrap();
+    session.send(WorkerCmd::Transfer(TransferJob {
+        direction: Direction::Upload,
+        src: up,
+        dest_dir: remote_dst.clone(),
+        recursive: false,
+        size_hint: 0,
+    }));
+    expect_done(&events, "upload");
+    assert_eq!(
+        std::fs::read(remote_dst.join("upload.txt")).unwrap(),
+        b"hello from local"
+    );
+
+    // Recursive directory download (scp -r copies the dir as a subdir of the destination).
+    let dl2 = sshd.dir.join("download2");
+    std::fs::create_dir_all(&dl2).unwrap();
+    session.send(WorkerCmd::Transfer(TransferJob {
+        direction: Direction::Download,
+        src: remote.clone(),
+        dest_dir: dl2.clone(),
+        recursive: true,
+        size_hint: 0,
+    }));
+    expect_done(&events, "recursive download");
+    assert_eq!(
+        std::fs::read(dl2.join("remote/sub/inner.txt")).unwrap(),
+        b"deep"
+    );
+
+    drop(session); // tears the master + control socket down
+}
+
+fn expect_done(rx: &Receiver<WorkerEvent>, what: &str) {
+    match recv_until(rx, |e| {
+        matches!(e, WorkerEvent::Done | WorkerEvent::Error(_))
+    }) {
+        WorkerEvent::Done => {}
+        WorkerEvent::Error(e) => panic!("{what} failed: {e}"),
+        _ => unreachable!(),
+    }
+}

--- a/src/transfer/e2e.rs
+++ b/src/transfer/e2e.rs
@@ -160,10 +160,11 @@ fn lists_and_transfers_both_directions() {
         return;
     };
 
-    // Remote tree (remote == localhost): a dir with a file and a nested subdir.
+    // Remote tree (remote == localhost): a dir with files (incl. a name with spaces) + a subdir.
     let remote = sshd.dir.join("remote");
     std::fs::create_dir_all(remote.join("sub")).unwrap();
     std::fs::write(remote.join("hello.txt"), b"hello from remote").unwrap();
+    std::fs::write(remote.join("a name with spaces.txt"), b"spaced").unwrap();
     std::fs::write(remote.join("sub/inner.txt"), b"deep").unwrap();
 
     let (session, events) = TransferSession::spawn(host_for(&sshd), false).unwrap();
@@ -208,6 +209,20 @@ fn lists_and_transfers_both_directions() {
         b"hello from remote"
     );
 
+    // Regression: a filename with spaces (scp's quoting corrupted these; sftp get/put is fine).
+    session.send(WorkerCmd::Transfer(TransferJob {
+        direction: Direction::Download,
+        src: remote.join("a name with spaces.txt"),
+        dest_dir: dl.clone(),
+        recursive: false,
+        size_hint: 0,
+    }));
+    expect_done(&events, "spaced download");
+    assert_eq!(
+        std::fs::read(dl.join("a name with spaces.txt")).unwrap(),
+        b"spaced"
+    );
+
     // Upload a single file.
     let up = sshd.dir.join("upload.txt");
     std::fs::write(&up, b"hello from local").unwrap();
@@ -226,7 +241,23 @@ fn lists_and_transfers_both_directions() {
         b"hello from local"
     );
 
-    // Recursive directory download (scp -r copies the dir as a subdir of the destination).
+    // Regression: upload a filename with spaces.
+    let up_spaced = sshd.dir.join("local with spaces.txt");
+    std::fs::write(&up_spaced, b"up spaced").unwrap();
+    session.send(WorkerCmd::Transfer(TransferJob {
+        direction: Direction::Upload,
+        src: up_spaced,
+        dest_dir: remote_dst.clone(),
+        recursive: false,
+        size_hint: 0,
+    }));
+    expect_done(&events, "spaced upload");
+    assert_eq!(
+        std::fs::read(remote_dst.join("local with spaces.txt")).unwrap(),
+        b"up spaced"
+    );
+
+    // Recursive directory download (sftp get -r mirrors the source dir into the dest path).
     let dl2 = sshd.dir.join("download2");
     std::fs::create_dir_all(&dl2).unwrap();
     session.send(WorkerCmd::Transfer(TransferJob {

--- a/src/transfer/e2e.rs
+++ b/src/transfer/e2e.rs
@@ -1,11 +1,11 @@
 //! End-to-end transfer tests against a throwaway, rootless `sshd` on localhost.
 //!
-//! These spawn a real `sshd` plus `ssh`/`sftp`/`scp`, so they are `#[ignore]`d — run them with
+//! These spawn a real `sshd` plus `ssh`/`sftp`, so they are `#[ignore]`d — run them with
 //! `cargo test -- --ignored` on a machine with OpenSSH installed. They drive the worker exactly
 //! as the transfer screen does (open the master, list a remote directory, copy files both ways,
-//! recursively), and confirm the ControlMaster + `sftp`/`scp` transport works against a real
-//! server. The unit tests cover the pure pieces (argv builders, `ls -l` parsing, progress math);
-//! this is the integration layer the M0 spike proved by hand.
+//! recursively, with a filename containing spaces), and confirm the ControlMaster + `sftp`
+//! transport works against a real server. The unit tests cover the pure pieces (argv builders,
+//! `ls -l` parsing, progress math); this is the integration layer the M0 spike proved by hand.
 
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -167,6 +167,11 @@ fn lists_and_transfers_both_directions() {
     std::fs::write(remote.join("a name with spaces.txt"), b"spaced").unwrap();
     std::fs::write(remote.join("sub/inner.txt"), b"deep").unwrap();
 
+    // Enable the diagnostic log and confirm it captures the commands (the `--transfer-log` /
+    // SSHELF_TRANSFER_LOG feature). SAFETY: this #[ignore]d test owns its process.
+    let log_path = sshd.dir.join("transfer.log");
+    unsafe { std::env::set_var(super::LOG_ENV, &log_path) };
+
     let (session, events) = TransferSession::spawn(host_for(&sshd), false).unwrap();
 
     // The master opens and reports a working directory.
@@ -272,6 +277,22 @@ fn lists_and_transfers_both_directions() {
         std::fs::read(dl2.join("remote/sub/inner.txt")).unwrap(),
         b"deep"
     );
+
+    // The diagnostic log recorded the master + the sftp commands (and no secrets to leak).
+    let logged = std::fs::read_to_string(&log_path).unwrap();
+    assert!(
+        logged.contains("$ ssh "),
+        "log should record the master command"
+    );
+    assert!(
+        logged.contains("sftp> get "),
+        "log should record get commands"
+    );
+    assert!(
+        logged.contains("sftp> put "),
+        "log should record put commands"
+    );
+    unsafe { std::env::remove_var(super::LOG_ENV) };
 
     drop(session); // tears the master + control socket down
 }

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -10,9 +10,12 @@
 //! `ssh -p` vs `sftp`/`scp -P` port-flag difference that would otherwise bite.
 #![allow(dead_code)] // protocol types + the session are wired into the UI (M3/M4)
 
+mod pane;
 mod worker;
 
-#[allow(unused_imports)] // the transfer screen (M3) consumes this re-export
+#[allow(unused_imports)] // the transfer screen (M3) consumes these re-exports
+pub use pane::{Pane, PaneEntry, Side, read_local_dir};
+#[allow(unused_imports)]
 pub use worker::TransferSession;
 
 use std::path::{Path, PathBuf};

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -8,15 +8,17 @@
 //! there is no re-auth and no per-file password prompt. Because the ride commands inherit the
 //! connection from the master, they need NONE of `-p`/`-i`/`-J` — which also sidesteps the
 //! `ssh -p` vs `sftp`/`scp -P` port-flag difference that would otherwise bite.
-#![allow(dead_code)] // protocol types + the session are wired into the UI (M3/M4)
-
+#[cfg(test)]
+mod e2e;
 mod pane;
+mod screen;
 mod worker;
 
-#[allow(unused_imports)] // the transfer screen (M3) consumes these re-exports
-pub use pane::{Pane, PaneEntry, Side, read_local_dir};
-#[allow(unused_imports)]
-pub use worker::TransferSession;
+pub use pane::{Pane, Side};
+// Part of `Pane::set_entries`' signature; named directly only by the renderer's tests.
+#[cfg_attr(not(test), allow(unused_imports))]
+pub use pane::PaneEntry;
+pub use screen::{TransferOutcome, TransferScreen};
 
 use std::path::{Path, PathBuf};
 
@@ -170,8 +172,9 @@ pub enum WorkerCmd {
 
 /// An event from the worker back to the UI, drained on each event-loop tick.
 pub enum WorkerEvent {
-    /// The master connection finished opening — `Ok` if it is up, `Err(msg)` if it failed.
-    Ready(Result<(), String>),
+    /// The master connection finished opening — `Ok(home)` carries the remote working directory
+    /// to start browsing from, `Err(msg)` reports why it failed.
+    Ready(Result<PathBuf, String>),
     /// A remote-directory listing completed.
     Listing {
         path: PathBuf,
@@ -188,7 +191,7 @@ pub enum WorkerEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::Host;
+    use crate::model::{AuthMethod, Host};
     use std::path::Path;
 
     fn host() -> Host {
@@ -216,6 +219,28 @@ mod tests {
         // …and reuses build_args: the endpoint is last and StrictHostKeyChecking is carried.
         assert_eq!(a.last().unwrap(), "deploy@10.0.0.1");
         assert!(a.iter().any(|s| s == "StrictHostKeyChecking=accept-new"));
+    }
+
+    #[test]
+    fn master_carries_jump_hosts_so_transfers_ride_them() {
+        // A ProxyJump target works: the master opens through the jump (key/agent), and
+        // sftp/scp ride that one connection — no per-command jump setup.
+        let mut h = host();
+        h.jump_hosts = vec!["bastion".into()];
+        let a = master_args(&h, Path::new("/tmp/cm"));
+        let j = a.iter().position(|s| s == "-J").expect("jump flag present");
+        assert_eq!(a[j + 1], "bastion");
+    }
+
+    #[test]
+    fn password_host_master_has_no_identity_flag() {
+        // Password hosts carry no `-i`; the secret is supplied to the master via SSH_ASKPASS
+        // (wired by the caller through ssh::configure_askpass), exactly as for connect.
+        let mut h = host();
+        h.auth = AuthMethod::Password;
+        let a = master_args(&h, Path::new("/tmp/cm"));
+        assert!(!a.iter().any(|s| s == "-i"));
+        assert_eq!(a.last().unwrap(), "deploy@10.0.0.1");
     }
 
     #[test]

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -8,7 +8,12 @@
 //! there is no re-auth and no per-file password prompt. Because the ride commands inherit the
 //! connection from the master, they need NONE of `-p`/`-i`/`-J` — which also sidesteps the
 //! `ssh -p` vs `sftp`/`scp -P` port-flag difference that would otherwise bite.
-#![allow(dead_code)] // builders + protocol types are wired into the worker (M1 IO) and UI (M3/M4)
+#![allow(dead_code)] // protocol types + the session are wired into the UI (M3/M4)
+
+mod worker;
+
+#[allow(unused_imports)] // the transfer screen (M3) consumes this re-export
+pub use worker::TransferSession;
 
 use std::path::{Path, PathBuf};
 
@@ -98,8 +103,13 @@ pub fn scp_args(control_path: &Path, recursive: bool, src: &str, dst: &str) -> V
 /// other metacharacters literal. The `user@host:` prefix is parsed by `scp` locally and must
 /// stay unquoted (scp splits on the first colon to separate host from path).
 pub fn remote_spec(target: &str, remote_path: &str) -> String {
-    let quoted = shlex::try_quote(remote_path).unwrap_or(std::borrow::Cow::Borrowed(remote_path));
-    format!("{target}:{quoted}")
+    format!("{target}:{}", shell_quote(remote_path))
+}
+
+/// Quote `s` for a remote shell (or sftp's `ls` parser). Falls back to the raw string only if
+/// it contains a NUL, which can't appear in a path anyway.
+pub(crate) fn shell_quote(s: &str) -> std::borrow::Cow<'_, str> {
+    shlex::try_quote(s).unwrap_or(std::borrow::Cow::Borrowed(s))
 }
 
 /// Live transfer progress: bytes moved so far out of the total. `bytes_total` is `0` until the
@@ -130,17 +140,25 @@ pub struct RemoteEntry {
     pub size: u64,
 }
 
+/// One transfer task: move `src` (a file or directory) into the other side's `dest_dir`.
+pub struct TransferJob {
+    pub direction: Direction,
+    /// Absolute path of the item to move, on the source side.
+    pub src: PathBuf,
+    /// Absolute directory on the destination side to drop it into.
+    pub dest_dir: PathBuf,
+    /// `src` is a directory (use `scp -r`).
+    pub recursive: bool,
+    /// Total bytes, when known (a single file's size), for the progress bar; `0` = indeterminate.
+    pub size_hint: u64,
+}
+
 /// A request from the UI thread to the transfer worker.
 pub enum WorkerCmd {
     /// List the remote directory at this absolute path.
     ListRemote(PathBuf),
-    /// Transfer `src` (a file or directory) into the other side's `dest_dir`.
-    Transfer {
-        direction: Direction,
-        src: PathBuf,
-        dest_dir: PathBuf,
-        recursive: bool,
-    },
+    /// Run a transfer.
+    Transfer(TransferJob),
     /// Cancel the in-flight transfer (if any).
     Cancel,
     /// Tear the master down and stop the worker.

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -24,6 +24,11 @@ use std::path::{Path, PathBuf};
 
 use crate::model::Host;
 
+/// Env var (also set by `--transfer-log <FILE>`) naming a file the worker appends transfer
+/// diagnostics to: the `ssh`/`sftp` commands and their stderr. No secrets are logged — the
+/// password reaches `ssh` via `SSH_ASKPASS`, never argv.
+pub(crate) const LOG_ENV: &str = "SSHELF_TRANSFER_LOG";
+
 /// Direction of a transfer, named by where the bytes end up.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Direction {

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -4,10 +4,10 @@
 //! Transport model (validated by the M0 spike — see `docs/decisions.md`): authenticate ONCE by
 //! opening a backgrounded `ssh` ControlMaster, which reuses *every* part of sshelf's auth via
 //! [`crate::ssh::build_args`] + `SSH_ASKPASS` (keys, agent, ProxyJump, port, and the stored
-//! keyring/vault secret). `sftp`/`scp` then ride that master with only `-o ControlPath`, so
-//! there is no re-auth and no per-file password prompt. Because the ride commands inherit the
-//! connection from the master, they need NONE of `-p`/`-i`/`-J` — which also sidesteps the
-//! `ssh -p` vs `sftp`/`scp -P` port-flag difference that would otherwise bite.
+//! keyring/vault secret). `sftp` then rides that master with only `-o ControlPath`, so there is
+//! no re-auth and no per-file password prompt. Because the ride commands inherit the connection
+//! from the master, they need NONE of `-p`/`-i`/`-J`. Transfers use `sftp` `get`/`put` (not
+//! `scp`): `sftp` quotes paths via its own parser consistently across OpenSSH versions.
 #[cfg(test)]
 mod e2e;
 mod pane;
@@ -33,7 +33,7 @@ pub enum Direction {
     Download,
 }
 
-/// The `user@host` destination shared by the master and the `sftp`/`scp` ride commands.
+/// The `user@host` destination shared by the master and the `sftp` ride commands.
 pub fn target(host: &Host) -> String {
     format!("{}@{}", host.effective_user(), host.hostname)
 }
@@ -74,8 +74,8 @@ fn control_op_args(op: &str, control_path: &Path, target: &str) -> Vec<String> {
     ]
 }
 
-/// `sftp -b -` argv that rides the master — used for directory listing (the worker feeds
-/// `ls -l …` on stdin). Only `-o ControlPath` + the destination: the master carries auth/port.
+/// `sftp -b -` argv that rides the master — the worker feeds `ls`/`get`/`put` batch lines on
+/// stdin. Only `-o ControlPath` + the destination: the master carries auth/port.
 pub fn sftp_batch_args(control_path: &Path, target: &str) -> Vec<String> {
     vec![
         "-b".to_string(),
@@ -86,33 +86,10 @@ pub fn sftp_batch_args(control_path: &Path, target: &str) -> Vec<String> {
     ]
 }
 
-/// `scp` argv that rides the master. `src`/`dst` are already-composed endpoints (a local path
-/// or a [`remote_spec`]). `-p` preserves mtimes/modes; `-r` recurses into directories. Like
-/// the other ride commands it carries only `-o ControlPath` — never `-p`(port)/`-i`/`-J`.
-pub fn scp_args(control_path: &Path, recursive: bool, src: &str, dst: &str) -> Vec<String> {
-    let mut a = vec![
-        "-o".to_string(),
-        format!("ControlPath={}", control_path.display()),
-        "-p".to_string(), // preserve mtimes/modes (scp's -p, not a port)
-    ];
-    if recursive {
-        a.push("-r".to_string());
-    }
-    a.push(src.to_string());
-    a.push(dst.to_string());
-    a
-}
-
-/// A remote `scp`/`sftp` endpoint: `user@host:quoted/path`. The path is shell-quoted because
-/// `scp` hands the remote path to the remote login shell — quoting keeps spaces, globs, and
-/// other metacharacters literal. The `user@host:` prefix is parsed by `scp` locally and must
-/// stay unquoted (scp splits on the first colon to separate host from path).
-pub fn remote_spec(target: &str, remote_path: &str) -> String {
-    format!("{target}:{}", shell_quote(remote_path))
-}
-
-/// Quote `s` for a remote shell (or sftp's `ls` parser). Falls back to the raw string only if
-/// it contains a NUL, which can't appear in a path anyway.
+/// Quote `s` for `sftp`'s command parser (used in `ls`/`get`/`put` batch lines). Falls back to
+/// the raw string only if it contains a NUL, which can't appear in a path anyway. Transfers go
+/// through `sftp` rather than `scp` precisely so this one quoting rule applies on every OpenSSH
+/// version — `scp`'s remote-path handling changed in OpenSSH 9 and takes shell quoting literally.
 pub(crate) fn shell_quote(s: &str) -> std::borrow::Cow<'_, str> {
     shlex::try_quote(s).unwrap_or(std::borrow::Cow::Borrowed(s))
 }
@@ -152,7 +129,7 @@ pub struct TransferJob {
     pub src: PathBuf,
     /// Absolute directory on the destination side to drop it into.
     pub dest_dir: PathBuf,
-    /// `src` is a directory (use `scp -r`).
+    /// `src` is a directory (transfer recursively).
     pub recursive: bool,
     /// Total bytes, when known (a single file's size), for the progress bar; `0` = indeterminate.
     pub size_hint: u64,
@@ -244,9 +221,9 @@ mod tests {
     }
 
     #[test]
-    fn ride_commands_carry_only_controlpath() {
-        // The master already holds port/identity/jump, so the ride commands must NOT repeat
-        // them — and a port flag here would be wrong anyway (sftp/scp use `-P`, not ssh's `-p`).
+    fn sftp_ride_command_carries_only_controlpath() {
+        // The master already holds port/identity/jump, so the ride command (used for listing
+        // and for get/put transfers) carries only the control socket + the destination.
         let cp = Path::new("/tmp/cm.sock");
         assert_eq!(
             sftp_batch_args(cp, "deploy@10.0.0.1"),
@@ -258,17 +235,6 @@ mod tests {
                 "deploy@10.0.0.1"
             ])
         );
-        let scp = scp_args(cp, false, "a.txt", "deploy@10.0.0.1:b.txt");
-        assert!(!scp.iter().any(|s| s == "-i" || s == "-J"));
-        assert!(scp.iter().any(|s| s == "ControlPath=/tmp/cm.sock"));
-        assert_eq!(scp[scp.len() - 2], "a.txt");
-        assert_eq!(scp[scp.len() - 1], "deploy@10.0.0.1:b.txt");
-    }
-
-    #[test]
-    fn scp_recursive_adds_dash_r() {
-        assert!(scp_args(Path::new("/tmp/cm"), true, "dir", "t:dir").contains(&"-r".to_string()));
-        assert!(!scp_args(Path::new("/tmp/cm"), false, "f", "t:f").contains(&"-r".to_string()));
     }
 
     #[test]
@@ -284,12 +250,12 @@ mod tests {
     }
 
     #[test]
-    fn remote_spec_quotes_metacharacters_in_the_path() {
-        let s = remote_spec("deploy@h", "/srv/my data/app.log");
-        assert!(s.starts_with("deploy@h:"));
-        assert!(s.contains("'/srv/my data/app.log'"));
-        // A plain path needs no quoting.
-        assert_eq!(remote_spec("deploy@h", "/srv/app"), "deploy@h:/srv/app");
+    fn shell_quote_wraps_spaces_but_leaves_plain_paths() {
+        assert_eq!(
+            shell_quote("/srv/my data/app.log"),
+            "'/srv/my data/app.log'"
+        );
+        assert_eq!(shell_quote("/srv/app"), "/srv/app");
     }
 
     #[test]

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -1,0 +1,270 @@
+//! Transfer engine core: the command lines for the dual-pane file-transfer screen, plus the
+//! worker/UI message protocol and progress math.
+//!
+//! Transport model (validated by the M0 spike — see `docs/decisions.md`): authenticate ONCE by
+//! opening a backgrounded `ssh` ControlMaster, which reuses *every* part of sshelf's auth via
+//! [`crate::ssh::build_args`] + `SSH_ASKPASS` (keys, agent, ProxyJump, port, and the stored
+//! keyring/vault secret). `sftp`/`scp` then ride that master with only `-o ControlPath`, so
+//! there is no re-auth and no per-file password prompt. Because the ride commands inherit the
+//! connection from the master, they need NONE of `-p`/`-i`/`-J` — which also sidesteps the
+//! `ssh -p` vs `sftp`/`scp -P` port-flag difference that would otherwise bite.
+#![allow(dead_code)] // builders + protocol types are wired into the worker (M1 IO) and UI (M3/M4)
+
+use std::path::{Path, PathBuf};
+
+use crate::model::Host;
+
+/// Direction of a transfer, named by where the bytes end up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    /// local → remote
+    Upload,
+    /// remote → local
+    Download,
+}
+
+/// The `user@host` destination shared by the master and the `sftp`/`scp` ride commands.
+pub fn target(host: &Host) -> String {
+    format!("{}@{}", host.effective_user(), host.hostname)
+}
+
+/// `ssh` argv that opens a backgrounded ControlMaster for `host`, held by the worker thread.
+/// `-N` holds the connection without a remote command; the master is created at `control_path`
+/// and [`crate::ssh::build_args`] is reused verbatim so keys/agent/ProxyJump/port and the
+/// stored secret (via `SSH_ASKPASS`, wired by the caller) all apply exactly as on connect.
+pub fn master_args(host: &Host, control_path: &Path) -> Vec<String> {
+    let mut a = vec![
+        "-N".to_string(),
+        "-o".to_string(),
+        "ControlMaster=yes".to_string(),
+        "-o".to_string(),
+        format!("ControlPath={}", control_path.display()),
+    ];
+    a.extend(crate::ssh::build_args(host, true));
+    a
+}
+
+/// `ssh -O check` argv — ask whether the master is alive (worker readiness poll).
+pub fn master_check_args(control_path: &Path, target: &str) -> Vec<String> {
+    control_op_args("check", control_path, target)
+}
+
+/// `ssh -O exit` argv — tell the master to close (teardown).
+pub fn master_exit_args(control_path: &Path, target: &str) -> Vec<String> {
+    control_op_args("exit", control_path, target)
+}
+
+fn control_op_args(op: &str, control_path: &Path, target: &str) -> Vec<String> {
+    vec![
+        "-O".to_string(),
+        op.to_string(),
+        "-o".to_string(),
+        format!("ControlPath={}", control_path.display()),
+        target.to_string(),
+    ]
+}
+
+/// `sftp -b -` argv that rides the master — used for directory listing (the worker feeds
+/// `ls -l …` on stdin). Only `-o ControlPath` + the destination: the master carries auth/port.
+pub fn sftp_batch_args(control_path: &Path, target: &str) -> Vec<String> {
+    vec![
+        "-b".to_string(),
+        "-".to_string(),
+        "-o".to_string(),
+        format!("ControlPath={}", control_path.display()),
+        target.to_string(),
+    ]
+}
+
+/// `scp` argv that rides the master. `src`/`dst` are already-composed endpoints (a local path
+/// or a [`remote_spec`]). `-p` preserves mtimes/modes; `-r` recurses into directories. Like
+/// the other ride commands it carries only `-o ControlPath` — never `-p`(port)/`-i`/`-J`.
+pub fn scp_args(control_path: &Path, recursive: bool, src: &str, dst: &str) -> Vec<String> {
+    let mut a = vec![
+        "-o".to_string(),
+        format!("ControlPath={}", control_path.display()),
+        "-p".to_string(), // preserve mtimes/modes (scp's -p, not a port)
+    ];
+    if recursive {
+        a.push("-r".to_string());
+    }
+    a.push(src.to_string());
+    a.push(dst.to_string());
+    a
+}
+
+/// A remote `scp`/`sftp` endpoint: `user@host:quoted/path`. The path is shell-quoted because
+/// `scp` hands the remote path to the remote login shell — quoting keeps spaces, globs, and
+/// other metacharacters literal. The `user@host:` prefix is parsed by `scp` locally and must
+/// stay unquoted (scp splits on the first colon to separate host from path).
+pub fn remote_spec(target: &str, remote_path: &str) -> String {
+    let quoted = shlex::try_quote(remote_path).unwrap_or(std::borrow::Cow::Borrowed(remote_path));
+    format!("{target}:{quoted}")
+}
+
+/// Live transfer progress: bytes moved so far out of the total. `bytes_total` is `0` until the
+/// size is known (the UI shows an indeterminate state then).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Progress {
+    pub bytes_done: u64,
+    pub bytes_total: u64,
+}
+
+impl Progress {
+    /// Completion as a whole percentage `0..=100`; `0` when the total isn't known yet.
+    pub fn percent(&self) -> u16 {
+        if self.bytes_total == 0 {
+            return 0;
+        }
+        let pct = self.bytes_done.saturating_mul(100) / self.bytes_total;
+        pct.min(100) as u16
+    }
+}
+
+/// A remote directory entry, parsed from `sftp`'s `ls -l` output by the worker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub is_symlink: bool,
+    pub size: u64,
+}
+
+/// A request from the UI thread to the transfer worker.
+pub enum WorkerCmd {
+    /// List the remote directory at this absolute path.
+    ListRemote(PathBuf),
+    /// Transfer `src` (a file or directory) into the other side's `dest_dir`.
+    Transfer {
+        direction: Direction,
+        src: PathBuf,
+        dest_dir: PathBuf,
+        recursive: bool,
+    },
+    /// Cancel the in-flight transfer (if any).
+    Cancel,
+    /// Tear the master down and stop the worker.
+    Shutdown,
+}
+
+/// An event from the worker back to the UI, drained on each event-loop tick.
+pub enum WorkerEvent {
+    /// The master connection finished opening — `Ok` if it is up, `Err(msg)` if it failed.
+    Ready(Result<(), String>),
+    /// A remote-directory listing completed.
+    Listing {
+        path: PathBuf,
+        entries: Vec<RemoteEntry>,
+    },
+    /// Progress on the in-flight transfer.
+    Progress(Progress),
+    /// The in-flight transfer completed successfully.
+    Done,
+    /// A listing or transfer failed; message is safe to show to the user.
+    Error(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Host;
+    use std::path::Path;
+
+    fn host() -> Host {
+        let mut h = Host::new("web", "10.0.0.1");
+        h.user = Some("deploy".into());
+        h
+    }
+
+    fn owned(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn target_is_user_at_host() {
+        assert_eq!(target(&host()), "deploy@10.0.0.1");
+    }
+
+    #[test]
+    fn master_args_open_a_controlmaster_and_reuse_build_args() {
+        let a = master_args(&host(), Path::new("/tmp/cm.sock"));
+        // Opens a master at our socket, holds the connection (`-N`)…
+        assert!(a.contains(&"-N".to_string()));
+        assert!(a.windows(2).any(|w| w == ["-o", "ControlMaster=yes"]));
+        assert!(a.iter().any(|s| s == "ControlPath=/tmp/cm.sock"));
+        // …and reuses build_args: the endpoint is last and StrictHostKeyChecking is carried.
+        assert_eq!(a.last().unwrap(), "deploy@10.0.0.1");
+        assert!(a.iter().any(|s| s == "StrictHostKeyChecking=accept-new"));
+    }
+
+    #[test]
+    fn ride_commands_carry_only_controlpath() {
+        // The master already holds port/identity/jump, so the ride commands must NOT repeat
+        // them — and a port flag here would be wrong anyway (sftp/scp use `-P`, not ssh's `-p`).
+        let cp = Path::new("/tmp/cm.sock");
+        assert_eq!(
+            sftp_batch_args(cp, "deploy@10.0.0.1"),
+            owned(&[
+                "-b",
+                "-",
+                "-o",
+                "ControlPath=/tmp/cm.sock",
+                "deploy@10.0.0.1"
+            ])
+        );
+        let scp = scp_args(cp, false, "a.txt", "deploy@10.0.0.1:b.txt");
+        assert!(!scp.iter().any(|s| s == "-i" || s == "-J"));
+        assert!(scp.iter().any(|s| s == "ControlPath=/tmp/cm.sock"));
+        assert_eq!(scp[scp.len() - 2], "a.txt");
+        assert_eq!(scp[scp.len() - 1], "deploy@10.0.0.1:b.txt");
+    }
+
+    #[test]
+    fn scp_recursive_adds_dash_r() {
+        assert!(scp_args(Path::new("/tmp/cm"), true, "dir", "t:dir").contains(&"-r".to_string()));
+        assert!(!scp_args(Path::new("/tmp/cm"), false, "f", "t:f").contains(&"-r".to_string()));
+    }
+
+    #[test]
+    fn control_ops_target_the_socket() {
+        assert_eq!(
+            master_check_args(Path::new("/tmp/cm"), "deploy@h"),
+            owned(&["-O", "check", "-o", "ControlPath=/tmp/cm", "deploy@h"])
+        );
+        assert_eq!(
+            master_exit_args(Path::new("/tmp/cm"), "deploy@h")[1],
+            "exit"
+        );
+    }
+
+    #[test]
+    fn remote_spec_quotes_metacharacters_in_the_path() {
+        let s = remote_spec("deploy@h", "/srv/my data/app.log");
+        assert!(s.starts_with("deploy@h:"));
+        assert!(s.contains("'/srv/my data/app.log'"));
+        // A plain path needs no quoting.
+        assert_eq!(remote_spec("deploy@h", "/srv/app"), "deploy@h:/srv/app");
+    }
+
+    #[test]
+    fn progress_percent_clamps_and_handles_unknown_total() {
+        assert_eq!(Progress::default().percent(), 0);
+        assert_eq!(
+            Progress {
+                bytes_done: 50,
+                bytes_total: 200
+            }
+            .percent(),
+            25
+        );
+        // Never exceeds 100, even if a stat overshoots.
+        assert_eq!(
+            Progress {
+                bytes_done: 999,
+                bytes_total: 100
+            }
+            .percent(),
+            100
+        );
+    }
+}

--- a/src/transfer/pane.rs
+++ b/src/transfer/pane.rs
@@ -41,7 +41,7 @@ impl PaneEntry {
         }
     }
 
-    fn is_parent(&self) -> bool {
+    pub fn is_parent(&self) -> bool {
         self.name == ".."
     }
 
@@ -71,7 +71,6 @@ impl From<RemoteEntry> for PaneEntry {
 }
 
 pub struct Pane {
-    pub side: Side,
     pub cwd: PathBuf,
     entries: Vec<PaneEntry>,
     /// Fuzzy filter over entry labels.
@@ -85,9 +84,8 @@ pub struct Pane {
 }
 
 impl Pane {
-    pub fn new(side: Side, cwd: PathBuf) -> Self {
+    pub fn new(cwd: PathBuf) -> Self {
         Pane {
-            side,
             cwd,
             entries: Vec::new(),
             query: String::new(),
@@ -156,6 +154,14 @@ impl Pane {
     pub fn selected_entry(&self) -> Option<&PaneEntry> {
         let visible = self.visible();
         visible.get(self.selected).map(|&i| &self.entries[i])
+    }
+
+    /// Whether the (unfiltered) listing already holds an entry named `name`, ignoring the
+    /// synthetic `..`. Used to avoid silently clobbering a destination on transfer.
+    pub fn contains(&self, name: &str) -> bool {
+        self.entries
+            .iter()
+            .any(|e| !e.is_parent() && e.name == name)
     }
 
     /// Entries to display, in filtered order, paired with their label.
@@ -275,7 +281,7 @@ mod tests {
 
     #[test]
     fn set_entries_prepends_parent_when_not_at_root() {
-        let mut p = Pane::new(Side::Local, PathBuf::from("/home/user/dir"));
+        let mut p = Pane::new(PathBuf::from("/home/user/dir"));
         p.set_entries(entries());
         assert_eq!(p.rows()[0].0.name, "..");
         assert_eq!(p.rows()[0].1, "../");
@@ -284,7 +290,7 @@ mod tests {
 
     #[test]
     fn root_has_no_parent_entry() {
-        let mut p = Pane::new(Side::Local, PathBuf::from("/"));
+        let mut p = Pane::new(PathBuf::from("/"));
         p.set_entries(entries());
         assert!(p.rows().iter().all(|(e, _)| !e.is_parent()));
     }
@@ -323,7 +329,7 @@ mod tests {
 
     #[test]
     fn typing_filters_and_navigate_clears_query() {
-        let mut p = Pane::new(Side::Local, PathBuf::from("/d"));
+        let mut p = Pane::new(PathBuf::from("/d"));
         p.set_entries(entries());
         p.push_query('a');
         p.push_query('l');
@@ -337,7 +343,7 @@ mod tests {
 
     #[test]
     fn move_sel_clamps_to_visible() {
-        let mut p = Pane::new(Side::Local, PathBuf::from("/d"));
+        let mut p = Pane::new(PathBuf::from("/d"));
         p.set_entries(entries()); // 3 rows: .., sub, alpha.txt
         p.move_sel(-1);
         assert_eq!(p.selected(), 0);
@@ -347,8 +353,18 @@ mod tests {
     }
 
     #[test]
+    fn contains_ignores_the_parent_entry() {
+        let mut p = Pane::new(PathBuf::from("/home/user/dir"));
+        p.set_entries(entries());
+        assert!(p.contains("alpha.txt"));
+        assert!(p.contains("sub"));
+        assert!(!p.contains(".."));
+        assert!(!p.contains("missing"));
+    }
+
+    #[test]
     fn set_error_replaces_entries() {
-        let mut p = Pane::new(Side::Remote, PathBuf::from("/srv"));
+        let mut p = Pane::new(PathBuf::from("/srv"));
         p.set_error("permission denied".into());
         assert!(!p.loading);
         assert_eq!(p.error.as_deref(), Some("permission denied"));

--- a/src/transfer/pane.rs
+++ b/src/transfer/pane.rs
@@ -1,0 +1,357 @@
+//! One side of the transfer screen: a fuzzy-filterable directory listing with navigation.
+//!
+//! A `Pane` is source-agnostic *state* — the screen loads its entries (the local side via
+//! [`read_local_dir`], the remote side via the worker) and hands them back with
+//! [`Pane::set_entries`]. The filter / selection / `visible` logic mirrors the key-picker file
+//! browser (`ui/browse.rs`); the local and remote listings are deliberately *not* unified
+//! behind a synchronous trait, because a remote `list()` would block the UI loop the worker
+//! exists to keep responsive.
+
+use std::path::{Path, PathBuf};
+
+use crate::search;
+
+use super::RemoteEntry;
+
+/// Which machine a pane browses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    Local,
+    Remote,
+}
+
+/// A directory entry shown in a pane. `name` is the bare basename; `size` is the file size in
+/// bytes (used as the progress total when transferring a single file).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaneEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub is_symlink: bool,
+    pub size: u64,
+}
+
+impl PaneEntry {
+    /// The synthetic parent entry shown at the top of a directory.
+    fn parent() -> Self {
+        PaneEntry {
+            name: "..".into(),
+            is_dir: true,
+            is_symlink: false,
+            size: 0,
+        }
+    }
+
+    fn is_parent(&self) -> bool {
+        self.name == ".."
+    }
+
+    /// Display label: `name/` for directories, `name@` for symlinks (ls -F style), else `name`.
+    /// Control characters are stripped so a hostile filename can't scramble the layout.
+    pub fn label(&self) -> String {
+        let name: String = self.name.chars().filter(|c| !c.is_control()).collect();
+        if self.is_dir {
+            format!("{name}/")
+        } else if self.is_symlink {
+            format!("{name}@")
+        } else {
+            name
+        }
+    }
+}
+
+impl From<RemoteEntry> for PaneEntry {
+    fn from(e: RemoteEntry) -> Self {
+        PaneEntry {
+            name: e.name,
+            is_dir: e.is_dir,
+            is_symlink: e.is_symlink,
+            size: e.size,
+        }
+    }
+}
+
+pub struct Pane {
+    pub side: Side,
+    pub cwd: PathBuf,
+    entries: Vec<PaneEntry>,
+    /// Fuzzy filter over entry labels.
+    query: String,
+    /// Selection index into the *visible* (filtered) entries.
+    selected: usize,
+    /// A listing is in flight (remote pane between request and reply).
+    pub loading: bool,
+    /// The last listing error, shown in place of entries.
+    pub error: Option<String>,
+}
+
+impl Pane {
+    pub fn new(side: Side, cwd: PathBuf) -> Self {
+        Pane {
+            side,
+            cwd,
+            entries: Vec::new(),
+            query: String::new(),
+            selected: 0,
+            loading: true,
+            error: None,
+        }
+    }
+
+    /// Move into `dir`: reset the view and mark it loading. The caller then loads the entries
+    /// (synchronously for local, or via the worker for remote) and calls [`set_entries`].
+    pub fn navigate_to(&mut self, dir: PathBuf) {
+        self.cwd = dir;
+        self.entries.clear();
+        self.query.clear();
+        self.selected = 0;
+        self.loading = true;
+        self.error = None;
+    }
+
+    /// The parent of the current directory, if any (for "go up").
+    pub fn parent(&self) -> Option<PathBuf> {
+        self.cwd.parent().map(Path::to_path_buf)
+    }
+
+    /// Replace the listing for the current directory. Prepends a `..` entry when the directory
+    /// has a parent, clears the loading/error state, and clamps the selection.
+    pub fn set_entries(&mut self, entries: Vec<PaneEntry>) {
+        let mut all = Vec::with_capacity(entries.len() + 1);
+        if self.cwd.parent().is_some() {
+            all.push(PaneEntry::parent());
+        }
+        all.extend(entries);
+        self.entries = all;
+        self.loading = false;
+        self.error = None;
+        let visible = self.visible().len();
+        if self.selected >= visible {
+            self.selected = visible.saturating_sub(1);
+        }
+    }
+
+    /// Record a listing failure to show in place of entries.
+    pub fn set_error(&mut self, message: String) {
+        self.entries.clear();
+        self.loading = false;
+        self.error = Some(message);
+    }
+
+    /// Indices into the full entry list that match the current filter, best-first.
+    pub fn visible(&self) -> Vec<usize> {
+        let labels: Vec<String> = self.entries.iter().map(PaneEntry::label).collect();
+        search::fuzzy_filter(&labels, &self.query)
+    }
+
+    pub fn query(&self) -> &str {
+        &self.query
+    }
+
+    /// The visible selection index, clamped to the current listing.
+    pub fn selected(&self) -> usize {
+        self.selected.min(self.visible().len().saturating_sub(1))
+    }
+
+    /// The entry under the selection, if any.
+    pub fn selected_entry(&self) -> Option<&PaneEntry> {
+        let visible = self.visible();
+        visible.get(self.selected).map(|&i| &self.entries[i])
+    }
+
+    /// Entries to display, in filtered order, paired with their label.
+    pub fn rows(&self) -> Vec<(&PaneEntry, String)> {
+        self.visible()
+            .into_iter()
+            .map(|i| (&self.entries[i], self.entries[i].label()))
+            .collect()
+    }
+
+    pub fn move_sel(&mut self, delta: isize) {
+        let n = self.visible().len();
+        if n == 0 {
+            self.selected = 0;
+            return;
+        }
+        self.selected = (self.selected as isize + delta).clamp(0, n as isize - 1) as usize;
+    }
+
+    pub fn push_query(&mut self, c: char) {
+        self.query.push(c);
+        self.selected = 0;
+    }
+
+    /// Remove the last filter char. Returns `false` if the filter was already empty (so the
+    /// caller can treat a further Backspace as "go up").
+    pub fn pop_query(&mut self) -> bool {
+        if self.query.is_empty() {
+            return false;
+        }
+        self.query.pop();
+        self.selected = 0;
+        true
+    }
+
+    /// Clear the filter. Returns `false` if it was already empty (so Esc can mean "close").
+    pub fn clear_query(&mut self) -> bool {
+        if self.query.is_empty() {
+            return false;
+        }
+        self.query.clear();
+        self.selected = 0;
+        true
+    }
+}
+
+/// Read a local directory into pane entries (dirs first, then case-insensitive by name). The
+/// `..` entry is added by [`Pane::set_entries`], not here.
+pub fn read_local_dir(cwd: &Path) -> Result<Vec<PaneEntry>, String> {
+    let rd = std::fs::read_dir(cwd).map_err(|e| format!("{}: {e}", cwd.display()))?;
+    let mut items: Vec<PaneEntry> = rd
+        .flatten()
+        .map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            // file_type() does not follow symlinks, so a symlink reads as a symlink.
+            let ft = e.file_type().ok();
+            let is_symlink = ft.is_some_and(|t| t.is_symlink());
+            let meta = e.metadata().ok(); // follows symlinks (so a link-to-dir shows as a dir)
+            let is_dir = meta.as_ref().is_some_and(std::fs::Metadata::is_dir);
+            let size = meta.as_ref().map(std::fs::Metadata::len).unwrap_or(0);
+            PaneEntry {
+                name,
+                is_dir,
+                is_symlink,
+                size,
+            }
+        })
+        .collect();
+    items.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+    Ok(items)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch() -> PathBuf {
+        let root = std::env::temp_dir().join(format!("sshelf-pane-{}", ulid::Ulid::new()));
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        std::fs::write(root.join("alpha.txt"), b"hello").unwrap();
+        std::fs::write(root.join("beta.log"), b"x").unwrap();
+        std::os::unix::fs::symlink(root.join("alpha.txt"), root.join("zlink")).unwrap();
+        root
+    }
+
+    fn entries() -> Vec<PaneEntry> {
+        vec![
+            PaneEntry {
+                name: "sub".into(),
+                is_dir: true,
+                is_symlink: false,
+                size: 0,
+            },
+            PaneEntry {
+                name: "alpha.txt".into(),
+                is_dir: false,
+                is_symlink: false,
+                size: 5,
+            },
+        ]
+    }
+
+    #[test]
+    fn read_local_dir_sorts_dirs_first_and_flags_symlinks() {
+        let items = read_local_dir(&scratch()).unwrap();
+        assert_eq!(items[0].name, "sub");
+        assert!(items[0].is_dir);
+        let link = items.iter().find(|e| e.name == "zlink").unwrap();
+        assert!(link.is_symlink);
+        let alpha = items.iter().find(|e| e.name == "alpha.txt").unwrap();
+        assert_eq!(alpha.size, 5);
+    }
+
+    #[test]
+    fn set_entries_prepends_parent_when_not_at_root() {
+        let mut p = Pane::new(Side::Local, PathBuf::from("/home/user/dir"));
+        p.set_entries(entries());
+        assert_eq!(p.rows()[0].0.name, "..");
+        assert_eq!(p.rows()[0].1, "../");
+        assert!(!p.loading);
+    }
+
+    #[test]
+    fn root_has_no_parent_entry() {
+        let mut p = Pane::new(Side::Local, PathBuf::from("/"));
+        p.set_entries(entries());
+        assert!(p.rows().iter().all(|(e, _)| !e.is_parent()));
+    }
+
+    #[test]
+    fn labels_mark_dirs_and_symlinks() {
+        let dir = PaneEntry {
+            name: "sub".into(),
+            is_dir: true,
+            is_symlink: false,
+            size: 0,
+        };
+        let link = PaneEntry {
+            name: "lnk".into(),
+            is_dir: false,
+            is_symlink: true,
+            size: 0,
+        };
+        assert_eq!(dir.label(), "sub/");
+        assert_eq!(link.label(), "lnk@");
+    }
+
+    #[test]
+    fn control_chars_are_stripped_from_labels() {
+        let nasty = PaneEntry {
+            name: "ev\u{1b}[2Jil".into(),
+            is_dir: false,
+            is_symlink: false,
+            size: 0,
+        };
+        let label = nasty.label();
+        // The ESC that would arm the escape sequence is gone, so the leftover "[2J" is inert.
+        assert!(!label.chars().any(char::is_control));
+        assert_eq!(label, "ev[2Jil");
+    }
+
+    #[test]
+    fn typing_filters_and_navigate_clears_query() {
+        let mut p = Pane::new(Side::Local, PathBuf::from("/d"));
+        p.set_entries(entries());
+        p.push_query('a');
+        p.push_query('l');
+        let names: Vec<&str> = p.rows().iter().map(|(e, _)| e.name.as_str()).collect();
+        assert!(names.contains(&"alpha.txt"));
+        assert!(!names.contains(&"sub"));
+        p.navigate_to(PathBuf::from("/d/sub"));
+        assert_eq!(p.query(), "");
+        assert!(p.loading);
+    }
+
+    #[test]
+    fn move_sel_clamps_to_visible() {
+        let mut p = Pane::new(Side::Local, PathBuf::from("/d"));
+        p.set_entries(entries()); // 3 rows: .., sub, alpha.txt
+        p.move_sel(-1);
+        assert_eq!(p.selected(), 0);
+        p.move_sel(100);
+        assert_eq!(p.selected(), 2);
+        assert_eq!(p.selected_entry().unwrap().name, "alpha.txt");
+    }
+
+    #[test]
+    fn set_error_replaces_entries() {
+        let mut p = Pane::new(Side::Remote, PathBuf::from("/srv"));
+        p.set_error("permission denied".into());
+        assert!(!p.loading);
+        assert_eq!(p.error.as_deref(), Some("permission denied"));
+        assert!(p.rows().is_empty());
+    }
+}

--- a/src/transfer/screen.rs
+++ b/src/transfer/screen.rs
@@ -1,0 +1,319 @@
+//! The dual-pane transfer screen: two [`Pane`]s (local + remote) over one [`TransferSession`].
+//!
+//! Key handling stays close to the rest of the app — `on_key` mutates state and returns an
+//! outcome — but the screen also drains the worker's events each tick (the event loop polls
+//! while this screen is open). Local navigation is synchronous (`std::fs`); remote navigation
+//! sends a request and updates when the listing arrives.
+//!
+//! Keys: type to filter · `Tab` switch panes · `↑/↓` move · `→`/`Enter` open a dir (or send a
+//! file) · `Ctrl-s` send the selection (file or folder) to the other pane · `←`/`Backspace` up
+//! · `Esc` cancel a transfer, else clear the filter, else close.
+
+use std::path::PathBuf;
+use std::sync::mpsc::Receiver;
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::model::Host;
+
+use super::pane::{Pane, Side, read_local_dir};
+use super::worker::TransferSession;
+use super::{Direction, Progress, TransferJob, WorkerCmd, WorkerEvent, target};
+
+/// State of the one in-flight transfer.
+struct Active {
+    progress: Progress,
+    /// Which pane to refresh once it completes.
+    dest: Side,
+    /// e.g. `report.pdf → deploy@host`, shown on the progress line.
+    label: String,
+}
+
+/// What the app should do after the screen handled a key.
+pub enum TransferOutcome {
+    Continue,
+    Close,
+}
+
+pub struct TransferScreen {
+    /// `user@host`, for the remote pane's title.
+    target: String,
+    session: TransferSession,
+    events: Receiver<WorkerEvent>,
+    local: Pane,
+    remote: Pane,
+    focus: Side,
+    /// The master is still being established; the remote pane shows "connecting…".
+    connecting: bool,
+    status: Option<String>,
+    active: Option<Active>,
+}
+
+impl TransferScreen {
+    /// Open the screen for `host`, spawning the worker and loading the local pane at `start`.
+    /// The remote pane fills in once the master reports its working directory.
+    pub fn open(host: &Host, has_secret: bool, start: PathBuf) -> std::io::Result<Self> {
+        let (session, events) = TransferSession::spawn(host.clone(), has_secret)?;
+        let mut local = Pane::new(start.clone());
+        match read_local_dir(&start) {
+            Ok(entries) => local.set_entries(entries),
+            Err(e) => local.set_error(e),
+        }
+        Ok(Self {
+            target: target(host),
+            session,
+            events,
+            local,
+            // Placeholder until WorkerEvent::Ready delivers the remote home directory.
+            remote: Pane::new(PathBuf::from("/")),
+            focus: Side::Local,
+            connecting: true,
+            status: None,
+            active: None,
+        })
+    }
+
+    pub fn on_key(&mut self, key: KeyEvent) -> TransferOutcome {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+
+        // While a transfer runs, only cancel / close are live.
+        if self.active.is_some() {
+            match (key.code, ctrl) {
+                (KeyCode::Esc, _) => {
+                    self.session.send(WorkerCmd::Cancel);
+                    self.status = Some("cancelling…".into());
+                }
+                (KeyCode::Char('c'), true) => return TransferOutcome::Close,
+                _ => {}
+            }
+            return TransferOutcome::Continue;
+        }
+
+        self.status = None;
+        match (key.code, ctrl) {
+            (KeyCode::Char('c'), true) => return TransferOutcome::Close,
+            (KeyCode::Esc, _) => {
+                if !self.focused().clear_query() {
+                    return TransferOutcome::Close;
+                }
+            }
+            (KeyCode::Tab, _) => self.focus = self.other_side(),
+            (KeyCode::Down, false) | (KeyCode::Char('n'), true) => self.focused().move_sel(1),
+            (KeyCode::Up, false) | (KeyCode::Char('p'), true) => self.focused().move_sel(-1),
+            (KeyCode::Enter, _) | (KeyCode::Right, false) => self.activate(),
+            (KeyCode::Char('s'), true) => self.transfer_selected(),
+            (KeyCode::Left, false) => self.go_up(),
+            (KeyCode::Backspace, _) => {
+                if !self.focused().pop_query() {
+                    self.go_up();
+                }
+            }
+            (KeyCode::Char(c), false) => self.focused().push_query(c),
+            _ => {}
+        }
+        TransferOutcome::Continue
+    }
+
+    /// Apply any pending worker events. Called once per event-loop tick.
+    pub fn drain_events(&mut self) {
+        while let Ok(event) = self.events.try_recv() {
+            match event {
+                WorkerEvent::Ready(Ok(home)) => {
+                    self.connecting = false;
+                    self.remote.navigate_to(home);
+                    self.request_remote();
+                }
+                WorkerEvent::Ready(Err(e)) => {
+                    self.connecting = false;
+                    self.remote.set_error(format!("connection failed: {e}"));
+                }
+                WorkerEvent::Listing { path, entries } => {
+                    // Ignore a listing for a directory we've since navigated away from.
+                    if path == self.remote.cwd {
+                        self.remote
+                            .set_entries(entries.into_iter().map(Into::into).collect());
+                    }
+                }
+                WorkerEvent::Progress(p) => {
+                    if let Some(active) = &mut self.active {
+                        active.progress = p;
+                    }
+                }
+                WorkerEvent::Done => {
+                    let dest = self.active.take().map(|a| a.dest);
+                    self.status = Some("transfer complete".into());
+                    match dest {
+                        Some(Side::Local) => self.reload_local(),
+                        Some(Side::Remote) => self.request_remote(),
+                        None => {}
+                    }
+                }
+                WorkerEvent::Error(e) => {
+                    if self.active.take().is_some() {
+                        self.status = Some(format!("transfer failed: {e}"));
+                    } else {
+                        // No transfer running, so it's a remote-listing failure.
+                        self.remote.set_error(e);
+                    }
+                }
+            }
+        }
+    }
+
+    /// `Enter`/`→`: descend into a directory, go up on `..`, or send a plain file.
+    fn activate(&mut self) {
+        let Some((is_parent, name, is_dir, is_symlink)) = self
+            .focused()
+            .selected_entry()
+            .map(|e| (e.is_parent(), e.name.clone(), e.is_dir, e.is_symlink))
+        else {
+            return;
+        };
+        if is_parent {
+            self.go_up();
+        } else if is_dir && !is_symlink {
+            let dir = self.focused().cwd.join(&name);
+            self.navigate(dir);
+        } else {
+            self.transfer_selected();
+        }
+    }
+
+    /// `Ctrl-s`: send the selected file or folder into the other pane's directory.
+    fn transfer_selected(&mut self) {
+        if self.active.is_some() {
+            self.status = Some("a transfer is already in progress".into());
+            return;
+        }
+        if self.connecting {
+            self.status = Some("still connecting…".into());
+            return;
+        }
+        let Some((is_parent, name, is_dir, is_symlink, size)) =
+            self.focused().selected_entry().map(|e| {
+                (
+                    e.is_parent(),
+                    e.name.clone(),
+                    e.is_dir,
+                    e.is_symlink,
+                    e.size,
+                )
+            })
+        else {
+            return;
+        };
+        if is_parent {
+            return;
+        }
+        if is_symlink {
+            self.status = Some(format!("\"{name}\" is a symlink — skipped in this version"));
+            return;
+        }
+        // v1 doesn't overwrite: if the destination already has this name, skip with a message.
+        if self.other().contains(&name) {
+            self.status = Some(format!(
+                "\"{name}\" already exists in the destination — skipped"
+            ));
+            return;
+        }
+
+        let src = self.focused().cwd.join(&name);
+        let dest_dir = self.other().cwd.clone();
+        let (direction, dest) = match self.focus {
+            Side::Local => (Direction::Upload, Side::Remote),
+            Side::Remote => (Direction::Download, Side::Local),
+        };
+        let dest_label = match dest {
+            Side::Local => "local".to_string(),
+            Side::Remote => self.target.clone(),
+        };
+        self.active = Some(Active {
+            progress: Progress::default(),
+            dest,
+            label: format!("{name} → {dest_label}"),
+        });
+        self.session.send(WorkerCmd::Transfer(TransferJob {
+            direction,
+            src,
+            dest_dir,
+            recursive: is_dir,
+            size_hint: if is_dir { 0 } else { size },
+        }));
+    }
+
+    fn navigate(&mut self, dir: PathBuf) {
+        match self.focus {
+            Side::Local => {
+                self.local.navigate_to(dir);
+                self.reload_local();
+            }
+            Side::Remote => {
+                self.remote.navigate_to(dir);
+                self.request_remote();
+            }
+        }
+    }
+
+    fn go_up(&mut self) {
+        if let Some(parent) = self.focused().parent() {
+            self.navigate(parent);
+        }
+    }
+
+    fn reload_local(&mut self) {
+        match read_local_dir(&self.local.cwd) {
+            Ok(entries) => self.local.set_entries(entries),
+            Err(e) => self.local.set_error(e),
+        }
+    }
+
+    fn request_remote(&self) {
+        self.session
+            .send(WorkerCmd::ListRemote(self.remote.cwd.clone()));
+    }
+
+    fn focused(&mut self) -> &mut Pane {
+        match self.focus {
+            Side::Local => &mut self.local,
+            Side::Remote => &mut self.remote,
+        }
+    }
+
+    fn other(&self) -> &Pane {
+        match self.focus {
+            Side::Local => &self.remote,
+            Side::Remote => &self.local,
+        }
+    }
+
+    fn other_side(&self) -> Side {
+        match self.focus {
+            Side::Local => Side::Remote,
+            Side::Remote => Side::Local,
+        }
+    }
+
+    // Read-only accessors for the renderer.
+    pub fn target(&self) -> &str {
+        &self.target
+    }
+    pub fn local_pane(&self) -> &Pane {
+        &self.local
+    }
+    pub fn remote_pane(&self) -> &Pane {
+        &self.remote
+    }
+    pub fn focused_side(&self) -> Side {
+        self.focus
+    }
+    pub fn is_connecting(&self) -> bool {
+        self.connecting
+    }
+    pub fn status(&self) -> Option<&str> {
+        self.status.as_deref()
+    }
+    /// The in-flight transfer's progress and label, if one is running.
+    pub fn active(&self) -> Option<(Progress, &str)> {
+        self.active.as_ref().map(|a| (a.progress, a.label.as_str()))
+    }
+}

--- a/src/transfer/worker.rs
+++ b/src/transfer/worker.rs
@@ -5,7 +5,6 @@
 //! [`WorkerCmd`], the worker emits [`WorkerEvent`] (drained each tick). The worker owns the
 //! master child and its control socket, and tears both down when it stops — on `Shutdown`, a
 //! dropped command channel, or a failed handshake.
-#![allow(dead_code)] // the session is wired into the transfer screen in M3/M4
 
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -115,12 +114,14 @@ fn run(host: Host, has_secret: bool, cmd_rx: Receiver<WorkerCmd>, events: Sender
         }
     };
 
-    if let Err(e) = handshake(&socket, &target, &mut master) {
+    if let Err(e) = handshake(&socket, &target, &mut master, &cmd_rx) {
         let _ = events.send(WorkerEvent::Ready(Err(e)));
         teardown(&mut master, &socket, &target);
         return;
     }
-    let _ = events.send(WorkerEvent::Ready(Ok(())));
+    // Start browsing from the remote working directory (the login/home dir); fall back to root.
+    let home = remote_home(&socket, &target).unwrap_or_else(|| PathBuf::from("/"));
+    let _ = events.send(WorkerEvent::Ready(Ok(home)));
 
     while let Ok(cmd) = cmd_rx.recv() {
         match cmd {
@@ -162,10 +163,21 @@ fn open_master(host: &Host, has_secret: bool, socket: &Path) -> std::io::Result<
 }
 
 /// Wait until `ssh -O check` reports the master is up, the master process exits (auth failed),
-/// or the timeout elapses.
-fn handshake(socket: &ControlSocket, target: &str, master: &mut Child) -> Result<(), String> {
+/// the screen closes (`Shutdown`/dropped channel), or the timeout elapses.
+fn handshake(
+    socket: &ControlSocket,
+    target: &str,
+    master: &mut Child,
+    cmd_rx: &Receiver<WorkerCmd>,
+) -> Result<(), String> {
     let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
     loop {
+        // Let the screen abort a slow connect promptly (so Drop's join doesn't block the UI).
+        if let Ok(WorkerCmd::Shutdown) | Err(TryRecvError::Disconnected) = cmd_rx.try_recv() {
+            let _ = master.kill();
+            let _ = master.wait();
+            return Err("cancelled".into());
+        }
         if master_alive(socket.path(), target) {
             return Ok(());
         }
@@ -243,6 +255,26 @@ fn list_remote(
             .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
     });
     Ok(entries)
+}
+
+/// Resolve the remote working directory via `sftp`'s `pwd` (`Remote working directory: …`).
+fn remote_home(socket: &ControlSocket, target: &str) -> Option<PathBuf> {
+    let mut child = Command::new("sftp")
+        .args(sftp_batch_args(socket.path(), target))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    {
+        let mut stdin = child.stdin.take()?;
+        let _ = stdin.write_all(b"pwd\n");
+    }
+    let out = child.wait_with_output().ok()?;
+    String::from_utf8_lossy(&out.stdout).lines().find_map(|l| {
+        l.split_once("Remote working directory:")
+            .map(|(_, path)| PathBuf::from(path.trim()))
+    })
 }
 
 /// Why a transfer ended other than success.

--- a/src/transfer/worker.rs
+++ b/src/transfer/worker.rs
@@ -6,6 +6,7 @@
 //! master child and its control socket, and tears both down when it stops — on `Shutdown`, a
 //! dropped command channel, or a failed handshake.
 
+use std::cell::RefCell;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -28,6 +29,31 @@ const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL: Duration = Duration::from_millis(100);
 /// Emit a progress event roughly this often (every Nth poll) to avoid UI jitter.
 const PROGRESS_EVERY: u32 = 5;
+
+/// Optional transfer diagnostics, enabled by the `SSHELF_TRANSFER_LOG` file path (or
+/// `--transfer-log`). Records the `ssh`/`sftp` commands and their stderr so a failure can be
+/// inspected after the fact — never any secret, since the password reaches `ssh` via
+/// `SSH_ASKPASS`, not argv. Lives on the single worker thread, so a `RefCell` suffices.
+struct DebugLog(Option<RefCell<std::fs::File>>);
+
+impl DebugLog {
+    fn from_env() -> Self {
+        let file = std::env::var_os(super::LOG_ENV).and_then(|path| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .ok()
+        });
+        DebugLog(file.map(RefCell::new))
+    }
+
+    fn log(&self, msg: &str) {
+        if let Some(file) = &self.0 {
+            let _ = writeln!(file.borrow_mut(), "{msg}");
+        }
+    }
+}
 
 /// A handle to the running transfer worker. Dropping it shuts the worker — and the master
 /// connection — down, and blocks until that teardown finishes (so the socket is gone even on a
@@ -102,10 +128,19 @@ impl Drop for ControlSocket {
 fn run(host: Host, has_secret: bool, cmd_rx: Receiver<WorkerCmd>, events: Sender<WorkerEvent>) {
     let target = target(&host);
     let socket = ControlSocket::new();
+    let dbg = DebugLog::from_env();
+    dbg.log(&format!(
+        "=== transfer session: {target} (askpass wired: {has_secret}) ===",
+    ));
+    dbg.log(&format!(
+        "$ ssh {}",
+        master_args(&host, socket.path()).join(" ")
+    ));
 
     let mut master = match open_master(&host, has_secret, socket.path()) {
         Ok(child) => child,
         Err(e) => {
+            dbg.log(&format!("could not launch ssh: {e}"));
             let _ = events.send(WorkerEvent::Ready(Err(format!(
                 "could not launch ssh: {e}"
             ))));
@@ -114,17 +149,19 @@ fn run(host: Host, has_secret: bool, cmd_rx: Receiver<WorkerCmd>, events: Sender
     };
 
     if let Err(e) = handshake(&socket, &target, &mut master, &cmd_rx) {
+        dbg.log(&format!("handshake failed: {e}"));
         let _ = events.send(WorkerEvent::Ready(Err(e)));
         teardown(&mut master, &socket, &target);
         return;
     }
     // Start browsing from the remote working directory (the login/home dir); fall back to root.
     let home = remote_home(&socket, &target).unwrap_or_else(|| PathBuf::from("/"));
+    dbg.log(&format!("master ready; remote home = {}", home.display()));
     let _ = events.send(WorkerEvent::Ready(Ok(home)));
 
     while let Ok(cmd) = cmd_rx.recv() {
         match cmd {
-            WorkerCmd::ListRemote(path) => match list_remote(&socket, &target, &path) {
+            WorkerCmd::ListRemote(path) => match list_remote(&socket, &target, &path, &dbg) {
                 Ok(entries) => {
                     let _ = events.send(WorkerEvent::Listing { path, entries });
                 }
@@ -132,15 +169,17 @@ fn run(host: Host, has_secret: bool, cmd_rx: Receiver<WorkerCmd>, events: Sender
                     let _ = events.send(WorkerEvent::Error(e));
                 }
             },
-            WorkerCmd::Transfer(job) => match transfer(&socket, &target, &job, &cmd_rx, &events) {
-                Ok(()) => {
-                    let _ = events.send(WorkerEvent::Done);
+            WorkerCmd::Transfer(job) => {
+                match transfer(&socket, &target, &job, &cmd_rx, &events, &dbg) {
+                    Ok(()) => {
+                        let _ = events.send(WorkerEvent::Done);
+                    }
+                    Err(TransferError::Cancelled) => dbg.log("transfer cancelled"),
+                    Err(TransferError::Failed(e)) => {
+                        let _ = events.send(WorkerEvent::Error(e));
+                    }
                 }
-                Err(TransferError::Cancelled) => {}
-                Err(TransferError::Failed(e)) => {
-                    let _ = events.send(WorkerEvent::Error(e));
-                }
-            },
+            }
             // A stray cancel with nothing running, or anything else: ignore.
             WorkerCmd::Cancel => {}
             WorkerCmd::Shutdown => break,
@@ -214,6 +253,7 @@ fn list_remote(
     socket: &ControlSocket,
     target: &str,
     path: &Path,
+    dbg: &DebugLog,
 ) -> Result<Vec<RemoteEntry>, String> {
     let mut child = Command::new("sftp")
         .args(sftp_batch_args(socket.path(), target))
@@ -223,12 +263,13 @@ fn list_remote(
         .spawn()
         .map_err(|e| format!("could not launch sftp: {e}"))?;
 
+    let line = format!("ls -l {}\n", shell_quote(&path.to_string_lossy()));
+    dbg.log(&format!("sftp> {}", line.trim_end()));
     {
         let mut stdin = child
             .stdin
             .take()
             .ok_or_else(|| "sftp stdin unavailable".to_string())?;
-        let line = format!("ls -l {}\n", shell_quote(&path.to_string_lossy()));
         stdin
             .write_all(line.as_bytes())
             .map_err(|e| format!("writing to sftp: {e}"))?;
@@ -239,8 +280,15 @@ fn list_remote(
         .wait_with_output()
         .map_err(|e| format!("sftp failed: {e}"))?;
     if !out.status.success() {
-        return Err(tidy_error(&String::from_utf8_lossy(&out.stderr))
-            .unwrap_or_else(|| format!("could not list {}", path.display())));
+        let err = String::from_utf8_lossy(&out.stderr);
+        dbg.log(&format!(
+            "  ls failed (exit {:?}):\n{}",
+            out.status.code(),
+            err.trim_end()
+        ));
+        return Err(
+            tidy_error(&err).unwrap_or_else(|| format!("could not list {}", path.display()))
+        );
     }
 
     let mut entries: Vec<RemoteEntry> = String::from_utf8_lossy(&out.stdout)
@@ -320,6 +368,7 @@ fn transfer(
     job: &TransferJob,
     cmd_rx: &Receiver<WorkerCmd>,
     events: &Sender<WorkerEvent>,
+    dbg: &DebugLog,
 ) -> Result<(), TransferError> {
     let name = job
         .src
@@ -328,6 +377,7 @@ fn transfer(
         .to_string_lossy()
         .into_owned();
     let (batch, local_dest) = transfer_batch(job, &name);
+    dbg.log(&format!("sftp> {}", batch.trim_end()));
 
     let mut child = Command::new("sftp")
         .args(sftp_batch_args(socket.path(), target))
@@ -370,10 +420,15 @@ fn transfer(
                     }
                     Ok(())
                 } else {
-                    Err(TransferError::Failed(child_error(
-                        &mut child,
-                        "transfer failed",
-                    )))
+                    let err = drain_stderr(&mut child);
+                    dbg.log(&format!(
+                        "  transfer failed (exit {:?}):\n{}",
+                        status.code(),
+                        err.trim_end()
+                    ));
+                    Err(TransferError::Failed(
+                        tidy_error(&err).unwrap_or_else(|| "transfer failed".into()),
+                    ))
                 };
             }
             Ok(None) => {}
@@ -413,13 +468,18 @@ fn local_size(path: &Path) -> u64 {
     std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
 }
 
-/// Read a child's captured stderr and return the most useful line, or `fallback`.
-fn child_error(child: &mut Child, fallback: &str) -> String {
+/// Take and return a child's captured stderr.
+fn drain_stderr(child: &mut Child) -> String {
     let mut buf = String::new();
     if let Some(mut err) = child.stderr.take() {
         let _ = err.read_to_string(&mut buf);
     }
-    tidy_error(&buf).unwrap_or_else(|| fallback.to_string())
+    buf
+}
+
+/// The most useful line of a child's stderr (ssh/sftp put the real cause last), or `fallback`.
+fn child_error(child: &mut Child, fallback: &str) -> String {
+    tidy_error(&drain_stderr(child)).unwrap_or_else(|| fallback.to_string())
 }
 
 /// The last non-blank line of `raw` (ssh/sftp/scp put the real cause last), if any.

--- a/src/transfer/worker.rs
+++ b/src/transfer/worker.rs
@@ -1,7 +1,7 @@
 //! The transfer worker thread and the `ssh` ControlMaster it owns.
 //!
-//! The TUI event loop is synchronous; this background thread runs the blocking `ssh`/`sftp`/
-//! `scp` so a slow link never freezes the UI. They talk over std channels: the UI sends
+//! The TUI event loop is synchronous; this background thread runs the blocking `ssh`/`sftp` so
+//! a slow link never freezes the UI. They talk over std channels: the UI sends
 //! [`WorkerCmd`], the worker emits [`WorkerEvent`] (drained each tick). The worker owns the
 //! master child and its control socket, and tears both down when it stops — on `Shutdown`, a
 //! dropped command channel, or a failed handshake.
@@ -19,8 +19,7 @@ use crate::ssh;
 
 use super::{
     Direction, Progress, RemoteEntry, TransferJob, WorkerCmd, WorkerEvent, master_args,
-    master_check_args, master_exit_args, remote_spec, scp_args, sftp_batch_args, shell_quote,
-    target,
+    master_check_args, master_exit_args, sftp_batch_args, shell_quote, target,
 };
 
 /// Wait this long for the master to authenticate and come up before giving up.
@@ -285,7 +284,36 @@ enum TransferError {
     Failed(String),
 }
 
-/// Run one transfer with `scp`, emitting progress and honoring a mid-flight cancel.
+/// Build the `sftp` batch line for a transfer, plus the local destination to poll for download
+/// progress. Paths are quoted for sftp's own command parser, which is consistent across OpenSSH
+/// versions — unlike `scp`, whose remote-path handling switched to the SFTP protocol in OpenSSH
+/// 9 and then takes shell quoting literally, corrupting names with spaces.
+fn transfer_batch(job: &TransferJob, name: &str) -> (String, Option<PathBuf>) {
+    let flag = if job.recursive { "-r " } else { "" };
+    match job.direction {
+        Direction::Download => {
+            let local_dest = job.dest_dir.join(name);
+            let line = format!(
+                "get {flag}{} {}\n",
+                shell_quote(&job.src.to_string_lossy()),
+                shell_quote(&local_dest.to_string_lossy()),
+            );
+            (line, Some(local_dest))
+        }
+        Direction::Upload => {
+            let remote_dest = format!("{}/{name}", job.dest_dir.to_string_lossy());
+            let line = format!(
+                "put {flag}{} {}\n",
+                shell_quote(&job.src.to_string_lossy()),
+                shell_quote(&remote_dest),
+            );
+            (line, None)
+        }
+    }
+}
+
+/// Run one transfer with `sftp` (`put`/`get` over the master), emitting progress and honoring a
+/// mid-flight cancel.
 fn transfer(
     socket: &ControlSocket,
     target: &str,
@@ -296,43 +324,31 @@ fn transfer(
     let name = job
         .src
         .file_name()
-        .ok_or_else(|| TransferError::Failed("invalid source path".into()))?;
+        .ok_or_else(|| TransferError::Failed("invalid source path".into()))?
+        .to_string_lossy()
+        .into_owned();
+    let (batch, local_dest) = transfer_batch(job, &name);
 
-    // Compose the scp endpoints, and (for downloads) the local destination we poll for progress.
-    let (scp_src, scp_dst, local_dest) = match job.direction {
-        Direction::Download => {
-            let src = remote_spec(target, &job.src.to_string_lossy());
-            let dest = job.dest_dir.join(name);
-            let dst = dest.to_string_lossy().into_owned();
-            (src, dst, Some(dest))
-        }
-        Direction::Upload => {
-            let src = job.src.to_string_lossy().into_owned();
-            let remote_path = format!(
-                "{}/{}",
-                job.dest_dir.to_string_lossy(),
-                name.to_string_lossy()
-            );
-            (src, remote_spec(target, &remote_path), None)
-        }
-    };
-
-    let mut child = Command::new("scp")
-        .args(scp_args(socket.path(), job.recursive, &scp_src, &scp_dst))
-        .stdin(Stdio::null())
+    let mut child = Command::new("sftp")
+        .args(sftp_batch_args(socket.path(), target))
+        .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| TransferError::Failed(format!("could not launch scp: {e}")))?;
+        .map_err(|e| TransferError::Failed(format!("could not launch sftp: {e}")))?;
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(batch.as_bytes());
+        // dropped here → EOF → sftp runs the batch line, then exits
+    }
 
     let mut tick = 0u32;
     loop {
         match cmd_rx.try_recv() {
             Ok(WorkerCmd::Cancel) | Err(TryRecvError::Disconnected) => {
                 kill_and_reap(&mut child);
-                // A partial download leaves a stub file behind; clean it up.
+                // A partial download leaves a stub file/dir behind; clean it up.
                 if let Some(dest) = &local_dest {
-                    let _ = std::fs::remove_file(dest);
+                    let _ = std::fs::remove_file(dest).or_else(|_| std::fs::remove_dir_all(dest));
                 }
                 return Err(TransferError::Cancelled);
             }
@@ -361,7 +377,7 @@ fn transfer(
                 };
             }
             Ok(None) => {}
-            Err(e) => return Err(TransferError::Failed(format!("scp error: {e}"))),
+            Err(e) => return Err(TransferError::Failed(format!("sftp error: {e}"))),
         }
 
         if tick.is_multiple_of(PROGRESS_EVERY)
@@ -522,5 +538,37 @@ mod tests {
         assert!(a.path().starts_with("/tmp/"));
         assert!(a.path().to_string_lossy().len() < 104);
         assert_ne!(a.path(), b.path());
+    }
+
+    #[test]
+    fn transfer_batch_quotes_paths_for_sftp() {
+        use std::path::PathBuf;
+        // Upload a file whose name has spaces: sftp's parser needs the paths single-quoted
+        // (the bug that broke scp — which took the quotes literally).
+        let up = TransferJob {
+            direction: Direction::Upload,
+            src: PathBuf::from("/Users/me/my file.txt"),
+            dest_dir: PathBuf::from("/home/r/Downloads"),
+            recursive: false,
+            size_hint: 0,
+        };
+        let (line, dest) = transfer_batch(&up, "my file.txt");
+        assert_eq!(
+            line,
+            "put '/Users/me/my file.txt' '/home/r/Downloads/my file.txt'\n"
+        );
+        assert!(dest.is_none());
+
+        // Recursive download adds -r and reports the local destination to poll for progress.
+        let down = TransferJob {
+            direction: Direction::Download,
+            src: PathBuf::from("/srv/my data"),
+            dest_dir: PathBuf::from("/tmp/dl"),
+            recursive: true,
+            size_hint: 0,
+        };
+        let (line, dest) = transfer_batch(&down, "my data");
+        assert_eq!(line, "get -r '/srv/my data' '/tmp/dl/my data'\n");
+        assert_eq!(dest, Some(PathBuf::from("/tmp/dl/my data")));
     }
 }

--- a/src/transfer/worker.rs
+++ b/src/transfer/worker.rs
@@ -1,0 +1,494 @@
+//! The transfer worker thread and the `ssh` ControlMaster it owns.
+//!
+//! The TUI event loop is synchronous; this background thread runs the blocking `ssh`/`sftp`/
+//! `scp` so a slow link never freezes the UI. They talk over std channels: the UI sends
+//! [`WorkerCmd`], the worker emits [`WorkerEvent`] (drained each tick). The worker owns the
+//! master child and its control socket, and tears both down when it stops — on `Shutdown`, a
+//! dropped command channel, or a failed handshake.
+#![allow(dead_code)] // the session is wired into the transfer screen in M3/M4
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use crate::model::Host;
+use crate::ssh;
+
+use super::{
+    Direction, Progress, RemoteEntry, TransferJob, WorkerCmd, WorkerEvent, master_args,
+    master_check_args, master_exit_args, remote_spec, scp_args, sftp_batch_args, shell_quote,
+    target,
+};
+
+/// Wait this long for the master to authenticate and come up before giving up.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Poll cadence while waiting on a child (handshake readiness, transfer progress, cancel).
+const POLL: Duration = Duration::from_millis(100);
+/// Emit a progress event roughly this often (every Nth poll) to avoid UI jitter.
+const PROGRESS_EVERY: u32 = 5;
+
+/// A handle to the running transfer worker. Dropping it shuts the worker — and the master
+/// connection — down, and blocks until that teardown finishes (so the socket is gone even on a
+/// panic unwind).
+pub struct TransferSession {
+    cmd_tx: Sender<WorkerCmd>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl TransferSession {
+    /// Spawn the worker for `host` (`has_secret` decides whether to wire `SSH_ASKPASS`). The
+    /// master connection is opened on the worker thread; the first event is a
+    /// [`WorkerEvent::Ready`] reporting whether it came up. Returns the handle plus the channel
+    /// of events to drain in the UI loop.
+    pub fn spawn(host: Host, has_secret: bool) -> std::io::Result<(Self, Receiver<WorkerEvent>)> {
+        let (cmd_tx, cmd_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::channel();
+        let join = std::thread::Builder::new()
+            .name("sshelf-transfer".into())
+            .spawn(move || run(host, has_secret, cmd_rx, event_tx))?;
+        Ok((
+            Self {
+                cmd_tx,
+                join: Some(join),
+            },
+            event_rx,
+        ))
+    }
+
+    /// Queue a command for the worker. A send error means the worker already stopped, in which
+    /// case the screen is closing anyway, so it's ignored.
+    pub fn send(&self, cmd: WorkerCmd) {
+        let _ = self.cmd_tx.send(cmd);
+    }
+}
+
+impl Drop for TransferSession {
+    fn drop(&mut self) {
+        let _ = self.cmd_tx.send(WorkerCmd::Shutdown);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+/// The control socket for the master, kept short (AF_UNIX paths are capped near 104 bytes, and
+/// macOS's `$TMPDIR` is far too long) and removed on drop.
+struct ControlSocket {
+    path: PathBuf,
+}
+
+impl ControlSocket {
+    fn new() -> Self {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+        let path = PathBuf::from(format!("/tmp/sshelf-mux-{}-{seq}.sock", std::process::id()));
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ControlSocket {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// The worker thread body: open the master, then service commands until told to stop.
+fn run(host: Host, has_secret: bool, cmd_rx: Receiver<WorkerCmd>, events: Sender<WorkerEvent>) {
+    let target = target(&host);
+    let socket = ControlSocket::new();
+
+    let mut master = match open_master(&host, has_secret, socket.path()) {
+        Ok(child) => child,
+        Err(e) => {
+            let _ = events.send(WorkerEvent::Ready(Err(format!(
+                "could not launch ssh: {e}"
+            ))));
+            return;
+        }
+    };
+
+    if let Err(e) = handshake(&socket, &target, &mut master) {
+        let _ = events.send(WorkerEvent::Ready(Err(e)));
+        teardown(&mut master, &socket, &target);
+        return;
+    }
+    let _ = events.send(WorkerEvent::Ready(Ok(())));
+
+    while let Ok(cmd) = cmd_rx.recv() {
+        match cmd {
+            WorkerCmd::ListRemote(path) => match list_remote(&socket, &target, &path) {
+                Ok(entries) => {
+                    let _ = events.send(WorkerEvent::Listing { path, entries });
+                }
+                Err(e) => {
+                    let _ = events.send(WorkerEvent::Error(e));
+                }
+            },
+            WorkerCmd::Transfer(job) => match transfer(&socket, &target, &job, &cmd_rx, &events) {
+                Ok(()) => {
+                    let _ = events.send(WorkerEvent::Done);
+                }
+                Err(TransferError::Cancelled) => {}
+                Err(TransferError::Failed(e)) => {
+                    let _ = events.send(WorkerEvent::Error(e));
+                }
+            },
+            // A stray cancel with nothing running, or anything else: ignore.
+            WorkerCmd::Cancel => {}
+            WorkerCmd::Shutdown => break,
+        }
+    }
+    teardown(&mut master, &socket, &target);
+}
+
+/// Spawn the backgrounded `ssh` ControlMaster, reusing sshelf's askpass wiring so the stored
+/// secret authenticates it exactly as a normal connect would.
+fn open_master(host: &Host, has_secret: bool, socket: &Path) -> std::io::Result<Child> {
+    let mut cmd = Command::new("ssh");
+    cmd.args(master_args(host, socket));
+    ssh::configure_askpass(&mut cmd, host, has_secret);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped()); // kept so a failed handshake can explain itself
+    cmd.spawn()
+}
+
+/// Wait until `ssh -O check` reports the master is up, the master process exits (auth failed),
+/// or the timeout elapses.
+fn handshake(socket: &ControlSocket, target: &str, master: &mut Child) -> Result<(), String> {
+    let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+    loop {
+        if master_alive(socket.path(), target) {
+            return Ok(());
+        }
+        match master.try_wait() {
+            // The master exited before the socket appeared → authentication/connection failed.
+            Ok(Some(_)) => return Err(child_error(master, "connection failed")),
+            Ok(None) => {}
+            Err(e) => return Err(format!("ssh master error: {e}")),
+        }
+        if Instant::now() >= deadline {
+            let _ = master.kill();
+            let _ = master.wait();
+            return Err(
+                "timed out opening the connection (wrong password, or host unreachable)".into(),
+            );
+        }
+        std::thread::sleep(POLL);
+    }
+}
+
+/// True if a master is listening on `socket` (`ssh -O check` exits 0).
+fn master_alive(socket: &Path, target: &str) -> bool {
+    Command::new("ssh")
+        .args(master_check_args(socket, target))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// List a remote directory by running `sftp -b -` over the master and parsing `ls -l`.
+fn list_remote(
+    socket: &ControlSocket,
+    target: &str,
+    path: &Path,
+) -> Result<Vec<RemoteEntry>, String> {
+    let mut child = Command::new("sftp")
+        .args(sftp_batch_args(socket.path(), target))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("could not launch sftp: {e}"))?;
+
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "sftp stdin unavailable".to_string())?;
+        let line = format!("ls -l {}\n", shell_quote(&path.to_string_lossy()));
+        stdin
+            .write_all(line.as_bytes())
+            .map_err(|e| format!("writing to sftp: {e}"))?;
+        // stdin dropped here → EOF → sftp runs the batch and exits.
+    }
+
+    let out = child
+        .wait_with_output()
+        .map_err(|e| format!("sftp failed: {e}"))?;
+    if !out.status.success() {
+        return Err(tidy_error(&String::from_utf8_lossy(&out.stderr))
+            .unwrap_or_else(|| format!("could not list {}", path.display())));
+    }
+
+    let mut entries: Vec<RemoteEntry> = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(parse_ls_line)
+        .collect();
+    // Directories first, then case-insensitive by name — matches the local pane's ordering.
+    entries.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+    Ok(entries)
+}
+
+/// Why a transfer ended other than success.
+enum TransferError {
+    /// The UI asked to cancel (or its channel closed). Already handled; no event needed.
+    Cancelled,
+    /// The transfer failed; the message is safe to show.
+    Failed(String),
+}
+
+/// Run one transfer with `scp`, emitting progress and honoring a mid-flight cancel.
+fn transfer(
+    socket: &ControlSocket,
+    target: &str,
+    job: &TransferJob,
+    cmd_rx: &Receiver<WorkerCmd>,
+    events: &Sender<WorkerEvent>,
+) -> Result<(), TransferError> {
+    let name = job
+        .src
+        .file_name()
+        .ok_or_else(|| TransferError::Failed("invalid source path".into()))?;
+
+    // Compose the scp endpoints, and (for downloads) the local destination we poll for progress.
+    let (scp_src, scp_dst, local_dest) = match job.direction {
+        Direction::Download => {
+            let src = remote_spec(target, &job.src.to_string_lossy());
+            let dest = job.dest_dir.join(name);
+            let dst = dest.to_string_lossy().into_owned();
+            (src, dst, Some(dest))
+        }
+        Direction::Upload => {
+            let src = job.src.to_string_lossy().into_owned();
+            let remote_path = format!(
+                "{}/{}",
+                job.dest_dir.to_string_lossy(),
+                name.to_string_lossy()
+            );
+            (src, remote_spec(target, &remote_path), None)
+        }
+    };
+
+    let mut child = Command::new("scp")
+        .args(scp_args(socket.path(), job.recursive, &scp_src, &scp_dst))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| TransferError::Failed(format!("could not launch scp: {e}")))?;
+
+    let mut tick = 0u32;
+    loop {
+        match cmd_rx.try_recv() {
+            Ok(WorkerCmd::Cancel) | Err(TryRecvError::Disconnected) => {
+                kill_and_reap(&mut child);
+                // A partial download leaves a stub file behind; clean it up.
+                if let Some(dest) = &local_dest {
+                    let _ = std::fs::remove_file(dest);
+                }
+                return Err(TransferError::Cancelled);
+            }
+            // Ignore other commands mid-transfer; the UI blocks new actions while one runs.
+            Ok(_) => {}
+            Err(TryRecvError::Empty) => {}
+        }
+
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return if status.success() {
+                    // Final 100% tick so the bar lands full.
+                    if let Some(dest) = &local_dest {
+                        let done = local_size(dest);
+                        let _ = events.send(WorkerEvent::Progress(Progress {
+                            bytes_done: done,
+                            bytes_total: job.size_hint.max(done),
+                        }));
+                    }
+                    Ok(())
+                } else {
+                    Err(TransferError::Failed(child_error(
+                        &mut child,
+                        "transfer failed",
+                    )))
+                };
+            }
+            Ok(None) => {}
+            Err(e) => return Err(TransferError::Failed(format!("scp error: {e}"))),
+        }
+
+        if tick.is_multiple_of(PROGRESS_EVERY)
+            && let Some(dest) = &local_dest
+        {
+            let _ = events.send(WorkerEvent::Progress(Progress {
+                bytes_done: local_size(dest),
+                bytes_total: job.size_hint,
+            }));
+        }
+        tick = tick.wrapping_add(1);
+        std::thread::sleep(POLL);
+    }
+}
+
+/// Close the master politely via the mux, then make sure the process is gone.
+fn teardown(master: &mut Child, socket: &ControlSocket, target: &str) {
+    let _ = Command::new("ssh")
+        .args(master_exit_args(socket.path(), target))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    kill_and_reap(master);
+}
+
+fn kill_and_reap(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn local_size(path: &Path) -> u64 {
+    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+}
+
+/// Read a child's captured stderr and return the most useful line, or `fallback`.
+fn child_error(child: &mut Child, fallback: &str) -> String {
+    let mut buf = String::new();
+    if let Some(mut err) = child.stderr.take() {
+        let _ = err.read_to_string(&mut buf);
+    }
+    tidy_error(&buf).unwrap_or_else(|| fallback.to_string())
+}
+
+/// The last non-blank line of `raw` (ssh/sftp/scp put the real cause last), if any.
+fn tidy_error(raw: &str) -> Option<String> {
+    raw.lines()
+        .rev()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .map(str::to_string)
+}
+
+/// Parse one `sftp` `ls -l` line into a [`RemoteEntry`], or `None` for prompts, headers, and
+/// entries we don't browse (`.`/`..`, sockets/devices). The format (captured from OpenSSH):
+/// `mode  links  owner  group  size  month  day  time  PATH` — note `links` is `?` and `PATH`
+/// is the full path, so we take its basename. Symlinks show no ` -> target`, just an `l` mode.
+fn parse_ls_line(line: &str) -> Option<RemoteEntry> {
+    let line = line.trim_end();
+    let fields: Vec<&str> = line.split_whitespace().collect();
+    if fields.len() < 9 {
+        return None;
+    }
+    let mode = fields[0];
+    if mode.len() < 10 {
+        return None; // skip "sftp>" echoes, "total N", banners
+    }
+    let (is_dir, is_symlink) = match mode.as_bytes()[0] {
+        b'd' => (true, false),
+        b'l' => (false, true),
+        b'-' => (false, false),
+        _ => return None, // sockets/pipes/devices — not browseable in v1
+    };
+    let size = fields[4].parse::<u64>().unwrap_or(0);
+    // The name is field 8 onward (it may contain spaces); take its basename.
+    let raw_name = remainder_from_field(line, 8)?;
+    // Skip the self/parent entries. `ls -l` (no `-a`) omits them, but be defensive — and check
+    // the raw path's last component, since `Path::file_name("…/.")` yields the parent, not ".".
+    if raw_name == "." || raw_name == ".." || raw_name.ends_with("/.") || raw_name.ends_with("/..")
+    {
+        return None;
+    }
+    let name = Path::new(raw_name)
+        .file_name()?
+        .to_string_lossy()
+        .into_owned();
+    Some(RemoteEntry {
+        name,
+        is_dir,
+        is_symlink,
+        size,
+    })
+}
+
+/// The remainder of `line` from the `n`th (0-based) whitespace-delimited field onward, with
+/// internal spaces preserved (remote filenames can contain spaces).
+fn remainder_from_field(line: &str, n: usize) -> Option<&str> {
+    let mut rest = line.trim_start();
+    for _ in 0..n {
+        let end = rest.find(char::is_whitespace)?;
+        rest = rest[end..].trim_start();
+    }
+    (!rest.is_empty()).then_some(rest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_dir_file_and_symlink() {
+        let dir = parse_ls_line("drwxr-xr-x    ? me wheel          64 Jun 16 19:09 /tmp/d/subdir")
+            .unwrap();
+        assert_eq!(dir.name, "subdir");
+        assert!(dir.is_dir && !dir.is_symlink && dir.size == 64);
+
+        let file =
+            parse_ls_line("-rw-r--r--    ? me wheel        4096 Jun 16 19:09 /tmp/d/readme.txt")
+                .unwrap();
+        assert_eq!(file.name, "readme.txt");
+        assert!(!file.is_dir && !file.is_symlink && file.size == 4096);
+
+        let link =
+            parse_ls_line("lrwxr-xr-x    ? me wheel          10 Jun 16 19:09 /tmp/d/link").unwrap();
+        assert!(link.is_symlink && !link.is_dir);
+        assert_eq!(link.name, "link");
+    }
+
+    #[test]
+    fn keeps_spaces_in_names_and_takes_basename() {
+        let e =
+            parse_ls_line("-rw-r--r--    ? me wheel          7 Jun 16 19:09 /tmp/d/my notes.md")
+                .unwrap();
+        assert_eq!(e.name, "my notes.md");
+    }
+
+    #[test]
+    fn skips_prompts_dots_and_specials() {
+        assert!(parse_ls_line("sftp> ls -l /tmp/d").is_none());
+        assert!(parse_ls_line("").is_none());
+        assert!(parse_ls_line("drwxr-xr-x    ? me wheel  64 Jun 16 19:09 /tmp/d/.").is_none());
+        assert!(parse_ls_line("drwxrwxrwt    ? root wheel 2400 Jun 16 19:09 /tmp/d/..").is_none());
+        // A socket/pipe is not browseable.
+        assert!(parse_ls_line("srwxr-xr-x    ? me wheel  0 Jun 16 19:09 /tmp/d/sock").is_none());
+    }
+
+    #[test]
+    fn remainder_from_field_preserves_internal_spaces() {
+        let line = "a  b   c d   e f g h  the name here";
+        assert_eq!(remainder_from_field(line, 8), Some("the name here"));
+        assert_eq!(remainder_from_field("only four words here", 8), None);
+    }
+
+    #[test]
+    fn control_socket_path_is_short_and_unique() {
+        let a = ControlSocket::new();
+        let b = ControlSocket::new();
+        assert!(a.path().starts_with("/tmp/"));
+        assert!(a.path().to_string_lossy().len() < 104);
+        assert_ne!(a.path(), b.path());
+    }
+}

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -104,8 +104,7 @@ fn render_hint(frame: &mut Frame, app: &App, area: Rect) {
         );
         return;
     }
-    let hint =
-        "↵ connect  ^a add  ^e edit  ^d del  ^y yank  ^o import  F1 help  F2 settings  esc quit";
+    let hint = "↵ connect  ^a add  ^e edit  ^d del  ^y yank  ^t transfer  ^o import  F1 help  F2 settings  esc quit";
     frame.render_widget(
         Paragraph::new(hint).style(Style::default().fg(Color::DarkGray)),
         area,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ mod browse;
 mod help;
 mod list;
 pub(crate) mod settings;
+mod transfer;
 mod widgets;
 pub(crate) mod wizard;
 
@@ -67,6 +68,11 @@ fn parse_color(name: &str) -> Color {
 
 pub fn render(frame: &mut Frame, app: &App) {
     let _ = ACCENT.set(parse_color(&app.config.accent));
+    // The transfer screen owns the whole frame while open.
+    if let Some(t) = &app.transfer {
+        transfer::render(frame, t);
+        return;
+    }
     // Full-screen modals.
     if let Some(w) = &app.wizard {
         wizard::render(frame, w);

--- a/src/ui/transfer.rs
+++ b/src/ui/transfer.rs
@@ -1,0 +1,331 @@
+//! Rendering for the dual-pane transfer screen: two directory panes side by side, a progress/
+//! status line, and a hint bar. `render` pulls the pieces it needs off the screen into a
+//! borrowed [`View`] so the layout can be exercised with `TestBackend` (no live worker).
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragraph};
+
+use super::{accent, centered, highlight};
+use crate::search;
+use crate::transfer::{Pane, Progress, Side, TransferScreen};
+
+/// Everything the renderer needs, borrowed from the screen (and easy to build in tests).
+struct View<'a> {
+    local: &'a Pane,
+    remote: &'a Pane,
+    focus: Side,
+    target: &'a str,
+    connecting: bool,
+    status: Option<&'a str>,
+    active: Option<(Progress, &'a str)>,
+}
+
+pub fn render(frame: &mut Frame, screen: &TransferScreen) {
+    draw(
+        frame,
+        &View {
+            local: screen.local_pane(),
+            remote: screen.remote_pane(),
+            focus: screen.focused_side(),
+            target: screen.target(),
+            connecting: screen.is_connecting(),
+            status: screen.status(),
+            active: screen.active(),
+        },
+    );
+}
+
+fn draw(frame: &mut Frame, view: &View) {
+    let area = frame.area();
+    if area.width < 50 || area.height < 10 {
+        let msg = Paragraph::new("terminal too small").style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(msg, centered(area, 18, 1));
+        return;
+    }
+
+    let rows = Layout::vertical([
+        Constraint::Min(0),    // the two panes
+        Constraint::Length(2), // progress / status
+        Constraint::Length(1), // hint bar
+    ])
+    .split(area);
+
+    let cols =
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(rows[0]);
+    render_pane(
+        frame,
+        cols[0],
+        view.local,
+        "local",
+        view.focus == Side::Local,
+        false,
+    );
+    render_pane(
+        frame,
+        cols[1],
+        view.remote,
+        view.target,
+        view.focus == Side::Remote,
+        view.connecting,
+    );
+
+    render_footer(frame, rows[1], view);
+
+    frame.render_widget(
+        Paragraph::new("tab switch · ↑↓ move · → open · ^s send · ← up · esc cancel/close")
+            .style(Style::default().fg(Color::DarkGray)),
+        rows[2],
+    );
+}
+
+fn render_pane(
+    frame: &mut Frame,
+    area: Rect,
+    pane: &Pane,
+    title: &str,
+    focused: bool,
+    connecting: bool,
+) {
+    let border = if focused {
+        Style::default().fg(accent())
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let title_style = if focused {
+        Style::default().fg(accent()).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Gray)
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border)
+        .title(Span::styled(format!(" {title} "), title_style));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let rows = Layout::vertical([
+        Constraint::Length(1), // cwd
+        Constraint::Length(1), // filter
+        Constraint::Min(0),    // listing
+    ])
+    .split(inner);
+
+    frame.render_widget(
+        Paragraph::new(truncate_left(
+            &pane.cwd.to_string_lossy(),
+            rows[0].width as usize,
+        ))
+        .style(Style::default().fg(accent())),
+        rows[0],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("> ", Style::default().fg(accent())),
+            Span::raw(pane.query().to_string()),
+        ])),
+        rows[1],
+    );
+
+    if connecting {
+        return message(frame, rows[2], "connecting…", Color::DarkGray);
+    }
+    if let Some(err) = &pane.error {
+        return message(frame, rows[2], err, Color::Red);
+    }
+    if pane.loading {
+        return message(frame, rows[2], "loading…", Color::DarkGray);
+    }
+
+    let listing = pane.rows();
+    let mut matcher = search::matcher();
+    let hl = Style::default().fg(accent()).add_modifier(Modifier::BOLD);
+    let items: Vec<ListItem> = listing
+        .iter()
+        .map(|(e, label)| {
+            let base = if e.is_symlink {
+                Style::default().fg(Color::DarkGray)
+            } else if e.is_dir {
+                Style::default().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let idx = search::match_indices(label, pane.query(), &mut matcher);
+            ListItem::new(Line::from(highlight(label, &idx, base, hl)))
+        })
+        .collect();
+    let list = List::new(items)
+        .highlight_symbol("▸ ")
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    let mut state = ListState::default();
+    // Only the focused pane shows a selection.
+    if focused && !listing.is_empty() {
+        state.select(Some(pane.selected()));
+    }
+    frame.render_stateful_widget(list, rows[2], &mut state);
+}
+
+fn render_footer(frame: &mut Frame, area: Rect, view: &View) {
+    let rows = Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).split(area);
+    if let Some((progress, label)) = view.active {
+        let info = if progress.bytes_total > 0 {
+            format!(
+                "{label}   {} / {}",
+                human(progress.bytes_done),
+                human(progress.bytes_total)
+            )
+        } else {
+            format!("{label}   {} transferred…", human(progress.bytes_done))
+        };
+        frame.render_widget(
+            Paragraph::new(info).style(Style::default().fg(accent())),
+            rows[0],
+        );
+        if progress.bytes_total > 0 {
+            let gauge = Gauge::default()
+                .gauge_style(Style::default().fg(accent()))
+                .ratio(progress.percent() as f64 / 100.0)
+                .label(format!("{}%", progress.percent()));
+            frame.render_widget(gauge, rows[1]);
+        } else {
+            frame.render_widget(
+                Paragraph::new("esc to cancel").style(Style::default().fg(Color::DarkGray)),
+                rows[1],
+            );
+        }
+    } else if let Some(status) = view.status {
+        frame.render_widget(
+            Paragraph::new(status).style(Style::default().fg(accent())),
+            rows[0],
+        );
+    }
+}
+
+fn message(frame: &mut Frame, area: Rect, text: &str, color: Color) {
+    frame.render_widget(Paragraph::new(text).style(Style::default().fg(color)), area);
+}
+
+/// Truncate from the left so a long path's tail (the part that matters) stays visible.
+fn truncate_left(s: &str, width: usize) -> String {
+    if s.chars().count() <= width {
+        return s.to_string();
+    }
+    let tail: String = s.chars().rev().take(width.saturating_sub(1)).collect();
+    format!("…{}", tail.chars().rev().collect::<String>())
+}
+
+/// Bytes as a short human-readable size.
+fn human(n: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut value = n as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{n} B")
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transfer::PaneEntry;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use std::path::PathBuf;
+
+    fn pane(cwd: &str, names: &[(&str, bool)]) -> Pane {
+        let mut p = Pane::new(PathBuf::from(cwd));
+        p.set_entries(
+            names
+                .iter()
+                .map(|&(name, is_dir)| PaneEntry {
+                    name: name.into(),
+                    is_dir,
+                    is_symlink: false,
+                    size: 10,
+                })
+                .collect(),
+        );
+        p
+    }
+
+    fn snapshot(view: &View, w: u16, h: u16) -> String {
+        let mut term = Terminal::new(TestBackend::new(w, h)).unwrap();
+        term.draw(|f| draw(f, view)).unwrap();
+        let buf = term.backend().buffer();
+        let width = buf.area.width as usize;
+        buf.content()
+            .chunks(width)
+            .map(|r| r.iter().map(|c| c.symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn renders_both_panes_and_hint() {
+        let local = pane("/home/me", &[("docs", true), ("readme.md", false)]);
+        let remote = pane("/srv", &[("logs", true), ("app.conf", false)]);
+        let view = View {
+            local: &local,
+            remote: &remote,
+            focus: Side::Local,
+            target: "deploy@host",
+            connecting: false,
+            status: None,
+            active: None,
+        };
+        let snap = snapshot(&view, 80, 20);
+        assert!(snap.contains("local"));
+        assert!(snap.contains("deploy@host"));
+        assert!(snap.contains("docs/"));
+        assert!(snap.contains("app.conf"));
+        assert!(snap.contains("send"));
+    }
+
+    #[test]
+    fn shows_progress_while_transferring() {
+        let local = pane("/home/me", &[("big.iso", false)]);
+        let remote = pane("/srv", &[]);
+        let view = View {
+            local: &local,
+            remote: &remote,
+            focus: Side::Local,
+            target: "deploy@host",
+            connecting: false,
+            status: None,
+            active: Some((
+                Progress {
+                    bytes_done: 512,
+                    bytes_total: 1024,
+                },
+                "big.iso → deploy@host",
+            )),
+        };
+        let snap = snapshot(&view, 80, 20);
+        assert!(snap.contains("big.iso → deploy@host"));
+        assert!(snap.contains("50%"));
+    }
+
+    #[test]
+    fn tiny_terminal_clamps() {
+        let local = pane("/", &[]);
+        let remote = pane("/", &[]);
+        let view = View {
+            local: &local,
+            remote: &remote,
+            focus: Side::Local,
+            target: "h",
+            connecting: true,
+            status: None,
+            active: None,
+        };
+        assert!(snapshot(&view, 20, 5).contains("terminal too small"));
+    }
+}


### PR DESCRIPTION
## Dual-pane file transfer (`Ctrl-t`)

Press `Ctrl-t` on a host to open a two-pane browser — local files on the left,
the host's on the right — and move files or folders either direction over SFTP.

- **Fuzzy search on both panes**; `Tab` to switch, `→`/`Enter` to open a dir,
  `Ctrl-s` to send the selection (recursive for folders), `Esc` to cancel.
- **Authenticates once** via an `ssh` ControlMaster, reusing your existing auth
  (keys / agent / ProxyJump / stored password via `SSH_ASKPASS`) — no PTY, no
  per-file re-prompt. `~/.ssh/config` is never touched.
- **No new dependencies** — uses the system `ssh`/`sftp`. macOS + Linux.
- Live progress, no silent overwrites, symlinks flagged & skipped, spaces in
  filenames handled, and `--transfer-log <FILE>` for diagnostics.