### PR TITLE
Feat/sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow SemVer.
 
 ## [Unreleased]
 
+### Added
+- **Sites** — group hosts (one site per host, e.g. a data center / project), distinct from the
+  many-valued free-form tags. A site can carry **optional** shared SSH defaults — user, port,
+  ProxyJump (bastion), identity — that member hosts inherit at connect time where the host
+  leaves a field unset (the host always wins; auth stays per-host). The list **groups by site**
+  when idle and shows a `·site·` column + `site:NAME` filter while typing. Manage sites with
+  **F3** (create/edit/delete + their defaults); assign one in the add/edit form. CLI: `sshelf
+  sites [--json]`, `sshelf sites add NAME [-u/-p/-J/-i]`, and `sshelf add --site NAME`. Stored in
+  `hosts.toml` as `[[site]]` — old files load unchanged.
+
 ## [0.5.0] — 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ your editor, and adds things plain SSH config can't express as nicely:
 - **Dual-pane file transfer** (`Ctrl-t`) — a two-pane browser to copy files and folders to and
   from a host over SFTP/SCP, with fuzzy search on both sides and live progress. It authenticates
   once (reusing the host's keys/agent or stored password) and never touches `~/.ssh/config`.
-- **Guided add/edit form** — hostname, user, port, auth, jump hosts, tags, extra args.
+- **Guided add/edit form** — hostname, user, port, auth, jump hosts, tags, site, extra args.
+- **Sites** (`F3`) — group hosts (one per host, e.g. a data center) and optionally give the site
+  a **shared bastion + default user/port/key** that members inherit at connect time. The list
+  groups by site; `site:NAME` filters. Distinct from the many-valued, free-form tags.
 - **Auto-supplied passwords** for password-auth hosts (via `SSH_ASKPASS`; no `sshpass`, the
   secret never appears in `ps`). Stored in your OS keyring, or an encrypted vault.
 - **Jump hosts** (`ProxyJump`), **tags/groups** (`tag:prod`), and **frecency** ordering
@@ -83,18 +86,20 @@ sshelf -                     # reconnect to the most recently used host
 sshelf add                   # open the TUI add form
 sshelf add <name> -H <host>  # add a host non-interactively (see "Adding hosts from the CLI")
 sshelf print-command <host>  # print the generated ssh command without connecting
-sshelf list                  # print saved hosts
-sshelf list <query>          # filter the list: fuzzy text and/or tag:NAME (e.g. tag:prod)
+sshelf list                  # print saved hosts (with a ·site· column)
+sshelf list <query>          # filter: fuzzy text and/or tag:NAME / site:NAME (e.g. site:prod-dc)
 sshelf list --json [query]   # machine-readable output (host fields + the generated command)
+sshelf sites                 # list sites (member counts + shared defaults)
+sshelf sites add <name> -u deploy -J bastion   # define a site with shared defaults
 sshelf --config FILE         # use a specific config file (also: $SSHELF_CONFIG)
 sshelf --transfer-log FILE   # log transfer ssh/sftp commands + errors to FILE (debugging)
 sshelf import [--dry-run]    # read-only import from ~/.ssh/config
 echo "$PASS" | sshelf set-password <name>   # store a password (scriptable / headless)
 ```
 
-**Keys:** type to filter · `tag:NAME` to filter by tag · `↑/↓` move · `Enter` connect ·
+**Keys:** type to filter · `tag:NAME` / `site:NAME` to filter · `↑/↓` move · `Enter` connect ·
 `Ctrl-a` add · `Ctrl-e` edit · `Ctrl-d` delete · `Ctrl-y` yank the `ssh` command · `Ctrl-t`
-transfer files · `Ctrl-o` import · `F1` help · `F2` settings · `Esc`/`Ctrl-c` quit.
+transfer files · `Ctrl-o` import · `F1` help · `F2` settings · `F3` sites · `Esc`/`Ctrl-c` quit.
 
 In the **add/edit** form the Key field picks an identity: `←/→` cycles keys found in `~/.ssh`
 (including `.pem`), and `Enter` opens a file browser (type to fuzzy-filter) to choose a key

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -15,10 +15,17 @@ config hand-editable instead of buried in macOS `~/Library`.
 
 Directories are created on first run (`0700`). **Secrets are never written to `hosts.toml`.**
 
-## `Host` schema (`hosts.toml`)
+## `Host` / `Site` schema (`hosts.toml`)
 
 ```toml
-format_version = 1            # top-level; for future migrations
+format_version = 1            # top-level scalar; for future migrations
+
+[[site]]                      # optional; sites are listed before hosts (scalars-before-AoT)
+name      = "prod-dc"         # the name hosts reference (see host.site)
+user      = "deploy"          # optional default login for member hosts
+port      = 22                # optional default port
+jump_hosts = ["bastion.prod"] # optional default ProxyJump (the site's bastion)
+identity_files = ["~/.ssh/prod"]  # optional default key(s) (applied to key-auth members)
 
 [[host]]
 id        = "01J…"            # stable unique id (e.g. ULID/UUID); keys secrets & frecency
@@ -29,7 +36,8 @@ port      = 22                # optional; default 22
 auth      = "key"             # "key" | "password" | "agent"
 identity_files = ["~/.ssh/infra-key"]   # for auth="key"; repeatable (-i per entry)
 jump_hosts = ["bastion.example.com"]    # ProxyJump chain; key/agent auth only in v1
-tags      = ["prod", "db"]    # for filtering/grouping
+tags      = ["prod", "db"]    # many-valued, free-form; for filtering/grouping
+site      = "prod-dc"         # optional; one site (by name); groups + inherits its defaults
 extra_args = "-o ServerAliveInterval=30"  # raw, shlex-split, appended verbatim
 # NOTE: no password field — ever. auth="password" means "look up the secret by id".
 ```
@@ -38,7 +46,18 @@ Notes:
 - Optional fields use `Option<T>` in Rust with `#[serde(skip_serializing_if = "Option::is_none")]`
   so the TOML stays clean; new fields use `#[serde(default)]` for backward compatibility.
 - `identity_files` / `jump_hosts` / `tags` are `Vec<String>` (empty = absent).
-- `format_version` lets us migrate the schema later without breaking older files.
+- `format_version` lets us migrate the schema later without breaking older files. Adding `[[site]]`
+  and `host.site` needed **no** bump — old files load with `sites = []` / `site = None`.
+
+### Sites vs tags, and inheritance
+
+A **Site** is *one per host* and may carry optional shared SSH defaults; **tags** are
+many-valued free-form labels. At connect time a host is resolved into an *effective host*
+(`Host::with_site_defaults`): for `user`, `port`, `jump_hosts`, `identity_files`, the site's
+value fills in **only where the host leaves that field unset** — the host always wins. Auth is
+**not** inheritable. A host that names an **undefined** site still groups under that name but
+inherits nothing (graceful degradation). Renaming a site (F3 manager) cascades to member hosts;
+deleting one clears members' `site`. See [`decisions.md`](./decisions.md) D-020.
 
 ## Frecency state (`state.json`)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,6 +5,25 @@ whenever you make a non-trivial design choice.
 
 ---
 
+### D-020 · Sites: one-per-host grouping with optional inherited SSH defaults
+Hosts can belong to a **Site** (a data center / project), distinct from many-valued free-form
+`tags`. A site is **one per host** and may carry **optional** shared SSH defaults — `user`,
+`port`, `jump_hosts` (the bastion), `identity_files` — that members inherit at connect time
+**only where the host leaves that field unset** (the host always wins). A bare site (name only)
+is pure grouping. **Auth is not inheritable** (it stays per-host; inheriting it would change
+which fields apply and surprise users — a site can still carry a default identity that only
+takes effect for key-auth members). Inheritance is computed by resolving a host into an
+"effective host" (`Host::with_site_defaults`) at every Host→ssh-args boundary (connect, yank,
+transfer master, CLI print/list-json), leaving `ssh::build_args` untouched — chosen over
+threading `&[Site]` through `build_args` and its many callers/tests. Hosts reference a site **by
+name**; an undefined name **degrades gracefully** (pure grouping, no inheritance, no error).
+Stored in `hosts.toml` as `[[site]]` (sites before hosts; `format_version` unchanged — old files
+load with `sites = []`). The list **groups by site when idle** and shows a flat `·site·` column
++ `site:NAME` filter while typing. Renames in the F3 manager **cascade** to member hosts;
+deleting a site **clears** members' `site` (self-healing) rather than leaving a dangling name.
+Rejected: a single special tag (too weak — no inherited config); a separate sites file (one
+atomic `hosts.toml` is simpler and keeps the reference local).
+
 ### D-019 · File transfer rides an `ssh` ControlMaster; `sftp`/`scp` as subprocesses
 The dual-pane transfer screen moves files over the **system `sftp`/`scp` binaries**, not a Rust
 SSH library: every pure-Rust option either pulls C deps (libssh2) or forces `tokio` and can't

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -8,6 +8,19 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
 
 ---
 
+## 2026-06-17 — Sites: docs + feature complete (M5)
+
+- Docs synced: `decisions.md` D-020 (the Sites ADR), `data-model.md` (`[[site]]` schema +
+  inheritance/override + back-compat), `ux.md` (grouped/flat list, `site:` filter, F3 manager,
+  CLI table), `structure.md` (`ui/sites.rs` + model note), README (feature bullet, keys, usage),
+  CHANGELOG `[Unreleased]`.
+- **Sites is feature-complete:** one-per-host grouping with optional inherited SSH defaults
+  (bastion/user/port/identity); grouped-when-idle / flat-when-filtering list; wizard chooser; F3
+  manager with rename + delete cascades; and the full CLI. 145 tests + 1 e2e; clippy + fmt clean.
+  Ships in **v0.6.0** via the usual `feat/sites` branch → PR → cut-release.
+
+---
+
 ## 2026-06-17 — Sites: CLI surface (M4)
 
 - `sshelf add --site NAME` (`-s`) assigns a site (warns, non-fatally, if it isn't defined yet).

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -8,6 +8,21 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
 
 ---
 
+## 2026-06-17 — Sites: wizard chooser + F3 manager (M3)
+
+- The add/edit form gains a **Site** chooser (←/→ over the defined sites + "(none)"); editing a
+  host preselects its site.
+- New **F3 sites manager** (`ui/sites.rs`): a list of sites with add / edit / delete and an
+  inline form for each site's optional defaults (user/port/jump/identity, with name-uniqueness +
+  port validation). Name edits are tracked as renames; on save the app rewrites member hosts'
+  `site` and clears any host whose site was deleted (orphans self-heal). Help overlay + list hint
+  updated (`F3`, `site:`, and the previously-missing `^t`).
+- Tests: wizard chooser + preselect; manager add/edit/rename/delete/duplicate-reject; an
+  app-level F3 rename-cascade + delete-orphan end to end. 143 tests; clippy + fmt clean.
+- Next: CLI (`add --site`, `sites`/`sites add`, list column, completion), then docs.
+
+---
+
 ## 2026-06-17 — Sites: grouped/flat host list (M2)
 
 - The host list now **groups by site** when idle (`── {site} ({n}) ──` section headers, sites

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -8,6 +8,18 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
 
 ---
 
+## 2026-06-17 — Sites: CLI surface (M4)
+
+- `sshelf add --site NAME` (`-s`) assigns a site (warns, non-fatally, if it isn't defined yet).
+- `sshelf sites` lists defined sites with member counts + their defaults; `sshelf sites --json`
+  for scripts; `sshelf sites add NAME [-u/-p/-J/-i]` creates one.
+- `sshelf list` shows a `·site·` column; `--json` already carries the `site` field and a
+  `command` that reflects inheritance. Dynamic completion of site names on `--site`.
+- 145 tests (add `--site` + `sites` parse); clippy + fmt clean. Verified end to end.
+- Next: docs (D-020, data-model, ux, structure, README, CHANGELOG).
+
+---
+
 ## 2026-06-17 — Sites: wizard chooser + F3 manager (M3)
 
 - The add/edit form gains a **Site** chooser (←/→ over the defined sites + "(none)"); editing a

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -8,6 +8,19 @@ Reverse-chronological. Newest entry on top. Every change to the project adds an 
 
 ---
 
+## 2026-06-17 — Sites: grouped/flat host list (M2)
+
+- The host list now **groups by site** when idle (`── {site} ({n}) ──` section headers, sites
+  alphabetical, `(no site)` last) and shows a flat ranked list with a dim `·site·` column while
+  filtering. `recompute` builds a grouped `order` when the query is empty (`group_order`);
+  `order` still holds host indices only, so selection/navigation are unchanged — the renderer
+  maps the selected host past the non-selectable headers to the `ListState` index.
+- Tests: `group_order` sectioning (case-insensitive, `(no site)` last); render checks for the
+  grouped headers + the filtered site column. 135 tests; clippy + fmt clean.
+- Next: the wizard site chooser + F3 sites manager (M3), then CLI (M4).
+
+---
+
 ## 2026-06-17 — Sites: model + inheritance + search (M1)
 
 - New **Site** concept: a one-per-host grouping that may carry **optional** shared SSH defaults

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -3,8 +3,28 @@
 Reverse-chronological. Newest entry on top. Every change to the project adds an entry here
 (the docs-in-sync rule). Keep entries short: what changed, why, and what's next.
 
-**Current milestone:** dual-pane SFTP file transfer (`Ctrl-t`), targeting **v0.5.0**. v1
-acceptance gates closed.
+**Current milestone:** Sites — group hosts with optional inherited SSH defaults, targeting
+**v0.6.0**. v1 acceptance gates closed.
+
+---
+
+## 2026-06-17 — Sites: model + inheritance + search (M1)
+
+- New **Site** concept: a one-per-host grouping that may carry **optional** shared SSH defaults
+  (user/port/jump/identity) member hosts inherit at connect time. Bare site = pure grouping;
+  per-host fields always override; auth stays per-host. Distinct from many-valued `tags`.
+- `model.rs`: `Site` struct + `Host.site: Option<String>` (by name) + `HostsFile.sites`
+  (`[[site]]`, sites-first; no `format_version` bump — old files load unchanged). Inheritance
+  via `Host::with_site_defaults(&[Site])` (clone, fill only unset fields, id preserved; unknown
+  site name degrades to plain grouping) + `find_site` (case-insensitive). `search_haystack`
+  includes the site.
+- `search.rs`: `parse_query` now also yields an optional `site:NAME` token; `rank` filters by it.
+- Threaded resolution into every Host→ssh-args boundary: TUI connect/yank/transfer, CLI
+  connect/`-`/print-command/`list --json` command. `App.sites` loaded + persisted (and it
+  follows an F2 hosts-file move). Verified end-to-end via `print-command` + `list --json`.
+- 132 tests (model inheritance/degradation, `site:` filter, store round-trip + pre-sites
+  back-compat); clippy + fmt clean. No UI yet.
+- Next: the grouped/flat list (M2), then the wizard chooser + F3 sites manager (M3), CLI (M4).
 
 ---
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -4,7 +4,7 @@
 >
 > **All modules present:** `main`, `app`, `askpass`, `config`, `import`, `model`, `paths`,
 > `search`, `secrets`, `ssh`, `state`, `store`, `transfer/{mod,worker,pane,screen}`, `vault`,
-> `ui/{mod,list,help,widgets,wizard,browse,settings,transfer}`.
+> `ui/{mod,list,help,widgets,wizard,browse,settings,sites,transfer}`.
 > (`error.rs` was removed — the codebase uses `anyhow` throughout.)
 
 ## Repository
@@ -27,7 +27,7 @@ ssh-tui/                 (crate/binary name: `sshelf`)
 |---|---|
 | `main.rs` | Entry/dispatch. If `SSHELF_ASKPASS` is set → askpass mode (read `argv[1]`). Else clap parses: default TUI, or subcommands (`import`, `list`, `add`). |
 | `app.rs` | `App` state + synchronous event loop + screen routing (component orchestration). |
-| `model.rs` | `Host` struct + `AuthMethod` enum (`Key` / `Password` / `Agent`); serde derives. |
+| `model.rs` | `Host` + `Site` structs (+ `AuthMethod`); `Host::with_site_defaults`/`find_site` (site inheritance); serde derives. |
 | `store.rs` | Load/save `hosts.toml` with atomic write (temp + rename); load `config.toml`. |
 | `state.rs` | Frecency state (`use_count`, `last_used`) load/save (`state.json`); score computation. |
 | `secrets.rs` | `SecretStore` trait → keyring backend + `age`-vault fallback; `zeroize` on secrets. |
@@ -46,6 +46,7 @@ ssh-tui/                 (crate/binary name: `sshelf`)
 | `ui/wizard.rs` | Auth-aware add/edit form: fields, validation, key picker, opens the file browser. |
 | `ui/browse.rs` | File-browser modal (fuzzy-filtered) for picking a key file anywhere on disk. |
 | `ui/settings.rs` | Settings screen (F2): config-file display + editable hosts-file location. |
+| `ui/sites.rs` | Sites manager (F3): list + add/edit/delete sites and their optional defaults; emits renames for the app to cascade. |
 | `ui/help.rs` | Help overlay. |
 | `ui/widgets.rs` | Shared widgets: single-line text input (hand-rolled), keybind hint bar, confirm modal. |
 

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -39,6 +39,7 @@ list. Actions therefore use **Ctrl** (or function keys) to avoid being typed int
 |---|---|
 | _type_ | filter the list (fuzzy) |
 | `tag:NAME` | filter by tag; combine with text and repeat (`tag:prod tag:db`, AND) |
+| `site:NAME` | filter by site (one site per host) |
 | `↑` / `↓`, `Ctrl-p` / `Ctrl-n` | move selection |
 | `Enter` | connect to selected host (tears down TUI, `exec()`s ssh) — M3 |
 | `Ctrl-a` | add host (wizard) — M4 |
@@ -49,6 +50,7 @@ list. Actions therefore use **Ctrl** (or function keys) to avoid being typed int
 | `Ctrl-o` | import from `~/.ssh/config` (read-only) — M7 |
 | `F1` | help overlay |
 | `F2` | settings (config & hosts-file locations) |
+| `F3` | manage sites (create/edit/delete groups + their shared defaults) |
 | `Esc` | clear the query if non-empty, otherwise quit |
 | `Ctrl-c` | quit |
 
@@ -111,6 +113,25 @@ age vault) keyed by host id — **never** in `hosts.toml`. On edit, leaving it b
 existing secret. It's auto-supplied at connect time (see `ssh-command.md`). Deleting a host
 (`Ctrl-d`) removes the host, its frecency entry, and its stored secret.
 
+## Sites (`F3`)
+
+A **site** groups hosts (one per host — a data center / project) and, unlike tags, may carry
+**optional** shared SSH defaults — user, port, ProxyJump (bastion), identity — that member hosts
+inherit at connect time. A bare site (name only) is pure grouping; per-host fields always
+override the site's; auth stays per-host.
+
+- **In the list:** with an empty search box, hosts are grouped under `── site (n) ──` headers
+  (a `(no site)` group last); while filtering, the list is flat with a dim `·site·` column and a
+  `site:NAME` filter token.
+- **Assigning a site:** the add/edit form has a **Site** chooser (`←`/`→` over the defined sites
+  + `(none)`).
+- **Managing sites (`F3`):** a list with `a` add, `e`/`Enter` edit, `d` delete, `Ctrl-s` save,
+  `Esc` cancel. Each site's form is name + optional user/port/jump/identity. Renaming a site
+  updates its member hosts; deleting one clears members' site (nothing dangles). A host that names
+  an undefined site still groups under that name but inherits nothing.
+
+Inherited defaults appear in the generated command (yank, `print-command`, connect, transfers).
+
 ## Import (`Ctrl-o` / `sshelf import`)
 
 Parses `~/.ssh/config` **read-only** via `ssh2-config` and adds every host whose name isn't
@@ -159,9 +180,11 @@ reaches `ssh` via `SSH_ASKPASS`, never the command line.
 | `sshelf` | Launch the interactive TUI. |
 | `sshelf <host>` | Connect straight to a saved host by **name or id**, skipping the TUI — same connect path as `Enter` (frecency recorded before the `exec`, secret auto-supplied). A miss suggests close names; a name that collides with a subcommand (`list`, `import`, …) is reached via the TUI instead. |
 | `sshelf -` | Reconnect to the most-recently-used host (max `last_used` in the frecency state). Errors (without connecting) if there's no history yet. |
-| `sshelf add` | With **no args**, opens the TUI add form. With **args**, adds a host non-interactively: `NAME` + `-H/--hostname` required; `-u/--user`, `-p/--port`, `-a/--auth`, `-i/--identity` (repeatable, implies key auth), `-J/--jump`, `-t/--tag`, `--extra "<flags>"`, `--password-stdin` (reads the secret from stdin). Duplicate names are refused. |
-| `sshelf print-command <host>` | Print the generated, shell-quoted `ssh …` command for a saved host by **name or id**, without connecting or changing frecency. CLI equivalent of the TUI's `Ctrl-y` yank. |
-| `sshelf list [query]` | List hosts. `query` filters with the TUI's syntax — fuzzy text and/or `tag:NAME` (e.g. `sshelf list tag:prod`, `sshelf list web`). |
+| `sshelf add` | With **no args**, opens the TUI add form. With **args**, adds a host non-interactively: `NAME` + `-H/--hostname` required; `-u/--user`, `-p/--port`, `-a/--auth`, `-i/--identity` (repeatable, implies key auth), `-J/--jump`, `-t/--tag`, `-s/--site`, `--extra "<flags>"`, `--password-stdin` (reads the secret from stdin). Duplicate names are refused. |
+| `sshelf sites [--json]` | List defined sites with member counts + their shared defaults. |
+| `sshelf sites add NAME [-u/-p/-J/-i]` | Define a site (settings optional; edit later with F3). |
+| `sshelf print-command <host>` | Print the generated, shell-quoted `ssh …` command for a saved host by **name or id** (reflecting any inherited site defaults), without connecting or changing frecency. CLI equivalent of the TUI's `Ctrl-y` yank. |
+| `sshelf list [query]` | List hosts (with a `·site·` column). `query` filters with the TUI's syntax — fuzzy text and/or `tag:NAME` / `site:NAME` (e.g. `sshelf list site:prod-dc`). |
 | `sshelf list --json [query]` | Same selection, emitted as JSON (each host's fields + its generated `command`). Always valid JSON, even when empty — the stable surface for scripts/integrations. |
 | `sshelf import [--dry-run]` | Read-only import from `~/.ssh/config`. |
 | `sshelf set-password <host>` | Store a password (read from stdin) for a host. |

--- a/src/app.rs
+++ b/src/app.rs
@@ -111,15 +111,22 @@ impl App {
         app
     }
 
-    /// Re-rank the host list for the current query and clamp the selection.
+    /// Re-rank the host list for the current query and clamp the selection. When the query is
+    /// empty (idle) the order is grouped into site sections; while filtering it's the flat
+    /// ranked order (`order` always holds host indices — section headers are render-only).
     pub fn recompute(&mut self) {
-        self.order = search::rank(
+        let ranked = search::rank(
             &self.hosts,
             &self.query,
             &self.state,
             self.config.decay_rate,
             self.config.default_sort,
         );
+        self.order = if self.query.is_empty() {
+            group_order(&self.hosts, &ranked)
+        } else {
+            ranked
+        };
         if self.selected >= self.order.len() {
             self.selected = self.order.len().saturating_sub(1);
         }
@@ -446,6 +453,29 @@ impl App {
     }
 }
 
+/// Reorder ranked host indices into site sections: distinct sites in case-insensitive name
+/// order, the "(no site)" group last; within a section the hosts keep their ranked
+/// (frecency/name) order. Returns host indices only — the renderer adds the section headers.
+fn group_order(hosts: &[Host], ranked: &[usize]) -> Vec<usize> {
+    let mut keys: Vec<String> = ranked
+        .iter()
+        .filter_map(|&i| hosts[i].site.as_deref().map(str::to_lowercase))
+        .collect();
+    keys.sort();
+    keys.dedup();
+    let mut out = Vec::with_capacity(ranked.len());
+    for key in &keys {
+        out.extend(ranked.iter().copied().filter(|&i| {
+            hosts[i]
+                .site
+                .as_deref()
+                .is_some_and(|s| s.eq_ignore_ascii_case(key))
+        }));
+    }
+    out.extend(ranked.iter().copied().filter(|&i| hosts[i].site.is_none()));
+    out
+}
+
 /// Set up the terminal, run the loop, restore the terminal, then (if a host was chosen)
 /// perform the `exec()` handoff into ssh.
 pub fn run() -> Result<()> {
@@ -568,6 +598,23 @@ mod tests {
             Config::default(),
             paths,
         )
+    }
+
+    #[test]
+    fn group_order_sections_sites_alpha_then_no_site() {
+        let mut a = Host::new("a", "h");
+        a.site = Some("zeta".into());
+        let mut b = Host::new("b", "h");
+        b.site = Some("alpha".into());
+        let mut c = Host::new("c", "h");
+        c.site = Some("ALPHA".into()); // same section as b (case-insensitive)
+        let d = Host::new("d", "h"); // no site
+        let hosts = vec![a, b, c, d];
+        // ranked order is [0,1,2,3]; group_order keeps that order within each section.
+        let order = group_order(&hosts, &[0, 1, 2, 3]);
+        let names: Vec<&str> = order.iter().map(|&i| hosts[i].name.as_str()).collect();
+        // alpha section (b, c), then zeta (a), then the (no site) group (d).
+        assert_eq!(names, vec!["b", "c", "a", "d"]);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,6 +25,7 @@ use crate::store;
 use crate::transfer::{self, TransferOutcome};
 use crate::ui;
 use crate::ui::settings::{Settings, SettingsOutcome};
+use crate::ui::sites::{SitesManager, SitesOutcome};
 use crate::ui::wizard::{Wizard, WizardOutcome};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,6 +71,8 @@ pub struct App {
     pub wizard: Option<Wizard>,
     pub confirm: Option<ConfirmDelete>,
     pub settings: Option<Settings>,
+    /// The sites manager (F3), when open.
+    pub sites_manager: Option<SitesManager>,
     /// The dual-pane file-transfer screen, when open.
     pub transfer: Option<transfer::TransferScreen>,
     /// Transient status line (cleared on next keypress).
@@ -102,6 +105,7 @@ impl App {
             wizard: None,
             confirm: None,
             settings: None,
+            sites_manager: None,
             transfer: None,
             status: None,
             should_quit: false,
@@ -141,6 +145,11 @@ impl App {
         self.order.get(self.selected).copied()
     }
 
+    /// The defined site names, for the wizard's site chooser.
+    fn site_names(&self) -> Vec<String> {
+        self.sites.iter().map(|s| s.name.clone()).collect()
+    }
+
     fn persist_hosts(&self) -> Result<()> {
         let file = HostsFile {
             format_version: CURRENT_FORMAT_VERSION,
@@ -171,6 +180,10 @@ impl App {
         }
         if self.settings.is_some() {
             self.on_key_settings(key);
+            return Outcome::Continue;
+        }
+        if self.sites_manager.is_some() {
+            self.on_key_sites(key);
             return Outcome::Continue;
         }
         match self.screen {
@@ -210,9 +223,15 @@ impl App {
                     return Outcome::Transfer(i);
                 }
             }
-            (KeyCode::Char('a'), true) => self.wizard = Some(Wizard::new_add()),
+            (KeyCode::Char('a'), true) => {
+                let names = self.site_names();
+                self.wizard = Some(Wizard::new_add(&names));
+            }
             (KeyCode::Char('e'), true) => match self.current() {
-                Some(i) => self.wizard = Some(Wizard::from_host(&self.hosts[i])),
+                Some(i) => {
+                    let names = self.site_names();
+                    self.wizard = Some(Wizard::from_host(&self.hosts[i], &names));
+                }
                 None => self.set_status("no host selected"),
             },
             (KeyCode::Char('d'), true) => {
@@ -229,6 +248,7 @@ impl App {
             (KeyCode::Up, false) | (KeyCode::Char('p'), true) => self.move_up(),
             (KeyCode::F(1), _) => self.screen = Screen::Help,
             (KeyCode::F(2), _) => self.open_settings(),
+            (KeyCode::F(3), _) => self.open_sites(),
             (KeyCode::Backspace, _) => {
                 self.query.pop();
                 self.selected = 0;
@@ -292,6 +312,51 @@ impl App {
             self.config.hosts_file.clone(),
             self.paths.default_hosts_display(),
         ));
+    }
+
+    fn open_sites(&mut self) {
+        self.sites_manager = Some(SitesManager::new(self.sites.clone()));
+    }
+
+    fn on_key_sites(&mut self, key: KeyEvent) {
+        let outcome = match self.sites_manager.as_mut() {
+            Some(m) => m.handle_key(key),
+            None => return,
+        };
+        match outcome {
+            SitesOutcome::Continue => {}
+            SitesOutcome::Cancel => self.sites_manager = None,
+            SitesOutcome::Save { sites, renames } => {
+                self.sites_manager = None;
+                // Apply name changes to member hosts, then clear any host whose site no longer
+                // exists (so deletes self-heal — see decisions.md D-020).
+                for (old, new) in &renames {
+                    for h in &mut self.hosts {
+                        if h.site
+                            .as_deref()
+                            .is_some_and(|s| s.eq_ignore_ascii_case(old))
+                        {
+                            h.site = Some(new.clone());
+                        }
+                    }
+                }
+                let defined: std::collections::HashSet<String> =
+                    sites.iter().map(|s| s.name.to_lowercase()).collect();
+                for h in &mut self.hosts {
+                    if let Some(s) = &h.site
+                        && !defined.contains(&s.to_lowercase())
+                    {
+                        h.site = None;
+                    }
+                }
+                self.sites = sites;
+                match self.persist_hosts() {
+                    Ok(()) => self.set_status("sites saved"),
+                    Err(e) => self.set_status(format!("save failed: {e}")),
+                }
+                self.recompute();
+            }
+        }
     }
 
     fn on_key_settings(&mut self, key: KeyEvent) {
@@ -496,7 +561,8 @@ fn run_with(start_add: bool) -> Result<()> {
     let state = FrecencyState::load(&paths.state_file())?;
     let mut app = App::new(file.hosts, file.sites, state, config, paths);
     if start_add {
-        app.wizard = Some(Wizard::new_add());
+        let names = app.site_names();
+        app.wizard = Some(Wizard::new_add(&names));
     }
 
     let mut terminal = ratatui::init();
@@ -615,6 +681,35 @@ mod tests {
         let names: Vec<&str> = order.iter().map(|&i| hosts[i].name.as_str()).collect();
         // alpha section (b, c), then zeta (a), then the (no site) group (d).
         assert_eq!(names, vec!["b", "c", "a", "d"]);
+    }
+
+    #[test]
+    fn sites_manager_rename_cascades_and_delete_orphans() {
+        let mut app = test_app();
+        app.sites = vec![Site::new("dc1"), Site::new("dc2")];
+        app.hosts[0].site = Some("dc1".into());
+        app.hosts[1].site = Some("dc2".into());
+
+        app.on_key(key(KeyCode::F(3))); // open the sites manager
+        assert!(app.sites_manager.is_some());
+        app.on_key(key(KeyCode::Enter)); // edit dc1
+        for _ in 0..3 {
+            app.on_key(key(KeyCode::Backspace));
+        }
+        for c in "prod".chars() {
+            app.on_key(key(KeyCode::Char(c)));
+        }
+        app.on_key(ctrl(KeyCode::Char('s'))); // commit form: rename dc1 -> prod
+        app.on_key(key(KeyCode::Down)); // select dc2
+        app.on_key(key(KeyCode::Char('d'))); // confirm-delete prompt
+        app.on_key(key(KeyCode::Char('y'))); // delete dc2
+        app.on_key(ctrl(KeyCode::Char('s'))); // save the manager
+
+        assert!(app.sites_manager.is_none());
+        assert_eq!(app.sites.len(), 1);
+        assert_eq!(app.sites[0].name, "prod");
+        assert_eq!(app.hosts[0].site.as_deref(), Some("prod")); // rename cascaded
+        assert_eq!(app.hosts[1].site, None); // dc2 deleted -> host orphaned
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,7 @@ use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, Ke
 
 use crate::config::Config;
 use crate::import;
-use crate::model::{CURRENT_FORMAT_VERSION, Host, HostsFile};
+use crate::model::{CURRENT_FORMAT_VERSION, Host, HostsFile, Site};
 use crate::paths::Paths;
 use crate::search;
 use crate::secrets;
@@ -53,6 +53,8 @@ pub enum Outcome {
 
 pub struct App {
     pub hosts: Vec<Host>,
+    /// Defined sites (groups + optional inherited SSH defaults).
+    pub sites: Vec<Site>,
     pub state: FrecencyState,
     pub config: Config,
     pub paths: Paths,
@@ -78,10 +80,17 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(hosts: Vec<Host>, state: FrecencyState, config: Config, paths: Paths) -> Self {
+    pub fn new(
+        hosts: Vec<Host>,
+        sites: Vec<Site>,
+        state: FrecencyState,
+        config: Config,
+        paths: Paths,
+    ) -> Self {
         let hosts_path = config.hosts_path(&paths);
         let mut app = App {
             hosts,
+            sites,
             state,
             config,
             paths,
@@ -128,6 +137,7 @@ impl App {
     fn persist_hosts(&self) -> Result<()> {
         let file = HostsFile {
             format_version: CURRENT_FORMAT_VERSION,
+            sites: self.sites.clone(),
             hosts: self.hosts.clone(),
         };
         store::save_hosts(&self.hosts_path, &file)
@@ -309,6 +319,7 @@ impl App {
                     match store::load_hosts(&new_path) {
                         Ok(file) => {
                             self.hosts = file.hosts;
+                            self.sites = file.sites;
                             Ok(format!("using existing hosts at {}", new_path.display()))
                         }
                         Err(e) => Err(format!("could not read {}: {e}", new_path.display())),
@@ -316,6 +327,7 @@ impl App {
                 } else {
                     let file = HostsFile {
                         format_version: CURRENT_FORMAT_VERSION,
+                        sites: self.sites.clone(),
                         hosts: self.hosts.clone(),
                     };
                     match store::save_hosts(&new_path, &file) {
@@ -406,7 +418,9 @@ impl App {
     /// event loop calls this so the side effects (a worker thread, a secrets lookup) stay out
     /// of the testable `on_key`.
     fn open_transfer(&mut self, idx: usize) {
-        let host = self.hosts[idx].clone();
+        // Resolve the host's site defaults so transfers ride the site's bastion / use its
+        // default user; `id` is preserved so the secrets lookup below is unaffected.
+        let host = self.hosts[idx].with_site_defaults(&self.sites);
         let has_secret = secrets::get_password(&self.paths.vault_file(), &host.id)
             .ok()
             .flatten()
@@ -448,9 +462,9 @@ fn run_with(start_add: bool) -> Result<()> {
     paths.ensure_dirs()?;
     let _ = Config::ensure_default_file(&paths.config_file()); // best-effort
     let config = Config::load(&paths.config_file())?;
-    let hosts = store::load_hosts(&config.hosts_path(&paths))?.hosts;
+    let file = store::load_hosts(&config.hosts_path(&paths))?;
     let state = FrecencyState::load(&paths.state_file())?;
-    let mut app = App::new(hosts, state, config, paths);
+    let mut app = App::new(file.hosts, file.sites, state, config, paths);
     if start_add {
         app.wizard = Some(Wizard::new_add());
     }
@@ -461,7 +475,8 @@ fn run_with(start_add: bool) -> Result<()> {
     loop_result?;
 
     if let Some(idx) = app.pending_connect {
-        let host = app.hosts[idx].clone();
+        // Resolve the host's site defaults (bastion/user/port/identity) for the real connect.
+        let host = app.hosts[idx].with_site_defaults(&app.sites);
         // Persist usage BEFORE exec() — nothing runs after a successful exec.
         app.state.record_use(&host.id);
         if let Err(e) = app.state.save(&app.paths.state_file()) {
@@ -509,7 +524,7 @@ fn dispatch(app: &mut App, key: KeyEvent) {
             app.should_quit = true;
         }
         Outcome::Yank(idx) => {
-            let cmd = ssh::command_string(&app.hosts[idx]);
+            let cmd = ssh::command_string(&app.hosts[idx].with_site_defaults(&app.sites));
             if ssh::copy_to_clipboard(&cmd) {
                 app.set_status(format!("copied: {cmd}"));
             } else {
@@ -546,7 +561,13 @@ mod tests {
             data_dir: dir,
             config_file_override: None,
         };
-        App::new(hosts, FrecencyState::default(), Config::default(), paths)
+        App::new(
+            hosts,
+            Vec::new(),
+            FrecencyState::default(),
+            Config::default(),
+            paths,
+        )
     }
 
     #[test]
@@ -697,6 +718,7 @@ mod tests {
         let new_path = dir.join("hosts.toml");
         let existing = HostsFile {
             format_version: CURRENT_FORMAT_VERSION,
+            sites: Vec::new(),
             hosts: vec![Host::new("fromdisk", "9.9.9.9")],
         };
         store::save_hosts(&new_path, &existing).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use serde::Serialize;
 
 use crate::config::Config;
-use crate::model::{AuthMethod, Host};
+use crate::model::{AuthMethod, Host, Site};
 use crate::paths::{CONFIG_ENV, Paths};
 use crate::state::FrecencyState;
 
@@ -331,10 +331,13 @@ fn cmd_print_command(host_ref: &str) -> Result<()> {
     paths.ensure_dirs()?;
     let _ = Config::ensure_default_file(&paths.config_file()); // best-effort
     let cfg = Config::load(&paths.config_file())?;
-    let hosts = store::load_hosts(&cfg.hosts_path(&paths))?.hosts;
-    let host = resolve_host(&hosts, host_ref)
+    let file = store::load_hosts(&cfg.hosts_path(&paths))?;
+    let host = resolve_host(&file.hosts, host_ref)
         .with_context(|| format!("no host with name or id '{host_ref}'"))?;
-    println!("{}", ssh::command_string(host));
+    println!(
+        "{}",
+        ssh::command_string(&host.with_site_defaults(&file.sites))
+    );
     Ok(())
 }
 
@@ -344,14 +347,15 @@ fn cmd_list(query: &str, json: bool) -> Result<()> {
     let _ = Config::ensure_default_file(&paths.config_file()); // best-effort
     let cfg = Config::load(&paths.config_file())?;
     let hosts_path = cfg.hosts_path(&paths);
-    let hosts = store::load_hosts(&hosts_path)?.hosts;
+    let file = store::load_hosts(&hosts_path)?;
+    let (hosts, sites) = (file.hosts, file.sites);
     let st = FrecencyState::load(&paths.state_file())?;
     let order = search::rank(&hosts, query, &st, cfg.decay_rate, cfg.default_sort);
 
     // JSON must always be valid (even empty) for scripts — emit before the human messages.
     if json {
         let selected: Vec<&Host> = order.iter().map(|&i| &hosts[i]).collect();
-        println!("{}", hosts_to_json(&selected)?);
+        println!("{}", hosts_to_json(&selected, &sites)?);
         return Ok(());
     }
 
@@ -391,12 +395,14 @@ struct HostJson<'a> {
     command: String,
 }
 
-fn hosts_to_json(hosts: &[&Host]) -> Result<String> {
+/// `command` reflects the host's resolved site defaults; the flattened `host` fields stay
+/// exactly as stored on disk.
+fn hosts_to_json(hosts: &[&Host], sites: &[Site]) -> Result<String> {
     let items: Vec<HostJson> = hosts
         .iter()
         .map(|&h| HostJson {
             host: h,
-            command: ssh::command_string(h),
+            command: ssh::command_string(&h.with_site_defaults(sites)),
         })
         .collect();
     serde_json::to_string_pretty(&items).context("serializing hosts to JSON")
@@ -460,7 +466,8 @@ fn cmd_connect(host_ref: &str) -> Result<()> {
     paths.ensure_dirs()?;
     let _ = Config::ensure_default_file(&paths.config_file()); // best-effort
     let cfg = Config::load(&paths.config_file())?;
-    let hosts = store::load_hosts(&cfg.hosts_path(&paths))?.hosts;
+    let file = store::load_hosts(&cfg.hosts_path(&paths))?;
+    let (hosts, sites) = (file.hosts, file.sites);
 
     let Some(host) = resolve_host(&hosts, host_ref).cloned() else {
         let st = FrecencyState::load(&paths.state_file()).unwrap_or_default();
@@ -478,7 +485,7 @@ fn cmd_connect(host_ref: &str) -> Result<()> {
             names.join(", ")
         );
     };
-    connect(&host, &paths)
+    connect(&host.with_site_defaults(&sites), &paths)
 }
 
 /// Reconnect to the most-recently-used host (`sshelf -`).
@@ -487,16 +494,17 @@ fn cmd_connect_last() -> Result<()> {
     paths.ensure_dirs()?;
     let _ = Config::ensure_default_file(&paths.config_file()); // best-effort
     let cfg = Config::load(&paths.config_file())?;
-    let hosts = store::load_hosts(&cfg.hosts_path(&paths))?.hosts;
+    let file = store::load_hosts(&cfg.hosts_path(&paths))?;
     let st = FrecencyState::load(&paths.state_file())?;
     let id = last_used_id(&st)
         .context("no recent host yet — connect to one first, then `sshelf -` reconnects to it")?;
-    let host = hosts
+    let host = file
+        .hosts
         .iter()
         .find(|h| h.id == id)
         .cloned()
         .context("the last-used host is no longer in your list — run `sshelf list`")?;
-    connect(&host, &paths)
+    connect(&host.with_site_defaults(&file.sites), &paths)
 }
 
 /// Record frecency BEFORE `exec()` (nothing runs after a successful exec), wire `SSH_ASKPASS`
@@ -723,7 +731,7 @@ mod tests {
         let mut h = Host::new("web", "10.0.0.1");
         h.user = Some("root".into());
         let refs = vec![&h];
-        let j = hosts_to_json(&refs).unwrap();
+        let j = hosts_to_json(&refs, &[]).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&j).unwrap();
         assert!(parsed.is_array());
         assert_eq!(parsed[0]["name"], "web");

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,11 @@ enum Command {
         #[arg(add = ArgValueCandidates::new(host_name_candidates))]
         host: String,
     },
+    /// Manage sites (groups with optional shared SSH defaults): list them, or add one.
+    Sites {
+        #[command(subcommand)]
+        action: Option<SitesAction>,
+    },
     /// Print static shell completions to stdout (for packaging). For host-name completion,
     /// set up dynamic completions instead — see the README.
     Completions {
@@ -98,6 +103,34 @@ enum Command {
     },
     /// Print the man page (roff) to stdout.
     Man,
+}
+
+#[derive(Subcommand)]
+enum SitesAction {
+    /// List defined sites (the default action).
+    List {
+        /// Emit JSON instead of the human table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Define a new site. Settings are optional (a bare site is pure grouping); edit later in
+    /// the TUI with F3.
+    Add {
+        /// Site name (must be unique).
+        name: String,
+        /// Default login user for member hosts.
+        #[arg(short = 'u', long)]
+        user: Option<String>,
+        /// Default SSH port for member hosts.
+        #[arg(short = 'p', long)]
+        port: Option<u16>,
+        /// Default ProxyJump (bastion) — repeatable or comma-separated.
+        #[arg(short = 'J', long = "jump", value_name = "HOST", value_delimiter = ',')]
+        jump_hosts: Vec<String>,
+        /// Default identity file(s) for key-auth members — repeatable.
+        #[arg(short = 'i', long = "identity", value_name = "PATH")]
+        identity_files: Vec<String>,
+    },
 }
 
 /// Flags for non-interactive `sshelf add`. All optional, so bare `sshelf add` opens the TUI.
@@ -127,6 +160,9 @@ struct AddArgs {
     /// Tag for grouping/filtering (repeatable or comma-separated).
     #[arg(short = 't', long = "tag", value_name = "TAG", value_delimiter = ',')]
     tags: Vec<String>,
+    /// Site to assign (groups the host + may supply inherited SSH defaults). See `sshelf sites`.
+    #[arg(short = 's', long, value_name = "NAME", add = ArgValueCandidates::new(site_name_candidates))]
+    site: Option<String>,
     /// Extra raw ssh flags, appended verbatim (e.g. "-o BatchMode=yes"). Quote the whole value;
     /// hyphen-leading values are allowed here so the flags pass through.
     #[arg(long = "extra", value_name = "ARGS", allow_hyphen_values = true)]
@@ -168,6 +204,7 @@ impl AddArgs {
             || !self.identity_files.is_empty()
             || !self.jump_hosts.is_empty()
             || !self.tags.is_empty()
+            || self.site.is_some()
             || self.extra_args.is_some()
             || self.password_stdin
     }
@@ -198,6 +235,7 @@ impl AddArgs {
         host.identity_files = self.identity_files;
         host.jump_hosts = self.jump_hosts;
         host.tags = self.tags;
+        host.site = self.site;
         host.extra_args = self.extra_args;
         Ok(host)
     }
@@ -242,6 +280,7 @@ fn main() -> Result<()> {
         Some(Command::Import { dry_run }) => cmd_import(dry_run),
         Some(Command::SetPassword { host }) => cmd_set_password(&host),
         Some(Command::Print { host }) => cmd_print_command(&host),
+        Some(Command::Sites { action }) => cmd_sites(action),
         Some(Command::Completions { shell }) => {
             clap_complete::generate(shell, &mut Cli::command(), "sshelf", &mut std::io::stdout());
             Ok(())
@@ -370,16 +409,22 @@ fn cmd_list(query: &str, json: bool) -> Result<()> {
     }
     for &i in &order {
         let h = &hosts[i];
+        let site = h
+            .site
+            .as_deref()
+            .map(|s| format!("  ·{s}·"))
+            .unwrap_or_default();
         let tags = if h.tags.is_empty() {
             String::new()
         } else {
             format!("  [{}]", h.tags.join(", "))
         };
         println!(
-            "{:<20}  {:<28}  {}{}",
+            "{:<20}  {:<28}  {}{}{}",
             h.name,
             h.endpoint(),
             h.auth.as_str(),
+            site,
             tags
         );
     }
@@ -426,6 +471,13 @@ fn cmd_add(args: AddArgs) -> Result<()> {
             host.name
         );
     }
+    if let Some(site) = &host.site
+        && crate::model::find_site(&file.sites, site).is_none()
+    {
+        println!(
+            "note: site '{site}' isn't defined yet — add it with `sshelf sites add {site}` (or F3 in the TUI)"
+        );
+    }
 
     // Read the secret before writing anything, so empty stdin can't leave a half-added host.
     let secret = if read_secret {
@@ -457,6 +509,98 @@ fn cmd_add(args: AddArgs) -> Result<()> {
             "note: password auth set but no password stored — run `sshelf set-password {name}`"
         );
     }
+    Ok(())
+}
+
+fn cmd_sites(action: Option<SitesAction>) -> Result<()> {
+    match action {
+        Some(SitesAction::Add {
+            name,
+            user,
+            port,
+            jump_hosts,
+            identity_files,
+        }) => cmd_sites_add(name, user, port, jump_hosts, identity_files),
+        Some(SitesAction::List { json }) => cmd_sites_list(json),
+        None => cmd_sites_list(false),
+    }
+}
+
+fn cmd_sites_list(json: bool) -> Result<()> {
+    let paths = Paths::resolve()?;
+    paths.ensure_dirs()?;
+    let _ = Config::ensure_default_file(&paths.config_file()); // best-effort
+    let cfg = Config::load(&paths.config_file())?;
+    let file = store::load_hosts(&cfg.hosts_path(&paths))?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&file.sites).context("serializing sites to JSON")?
+        );
+        return Ok(());
+    }
+    if file.sites.is_empty() {
+        println!("No sites yet. Add one with `sshelf sites add <name>`, or in the TUI (F3).");
+        return Ok(());
+    }
+    for s in &file.sites {
+        let members = file
+            .hosts
+            .iter()
+            .filter(|h| {
+                h.site
+                    .as_deref()
+                    .is_some_and(|x| x.eq_ignore_ascii_case(&s.name))
+            })
+            .count();
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(u) = &s.user {
+            parts.push(format!("user={u}"));
+        }
+        if let Some(p) = s.port {
+            parts.push(format!("port={p}"));
+        }
+        if !s.jump_hosts.is_empty() {
+            parts.push(format!("jump={}", s.jump_hosts.join(",")));
+        }
+        if !s.identity_files.is_empty() {
+            parts.push(format!("identity={}", s.identity_files.join(",")));
+        }
+        let defaults = if parts.is_empty() {
+            "(grouping only)".to_string()
+        } else {
+            parts.join("  ")
+        };
+        println!("{:<20}  {} host(s)  {}", s.name, members, defaults);
+    }
+    Ok(())
+}
+
+fn cmd_sites_add(
+    name: String,
+    user: Option<String>,
+    port: Option<u16>,
+    jump_hosts: Vec<String>,
+    identity_files: Vec<String>,
+) -> Result<()> {
+    let paths = Paths::resolve()?;
+    paths.ensure_dirs()?;
+    let _ = Config::ensure_default_file(&paths.config_file()); // best-effort
+    let cfg = Config::load(&paths.config_file())?;
+    let hosts_path = cfg.hosts_path(&paths);
+    let mut file = store::load_hosts(&hosts_path)?;
+    if crate::model::find_site(&file.sites, &name).is_some() {
+        anyhow::bail!("a site named '{name}' already exists");
+    }
+    file.sites.push(Site {
+        name: name.clone(),
+        user,
+        port,
+        jump_hosts,
+        identity_files,
+    });
+    store::save_hosts(&hosts_path, &file)?;
+    println!("added site '{name}'");
     Ok(())
 }
 
@@ -559,6 +703,24 @@ fn host_candidates_from(hosts: &[Host]) -> Vec<CompletionCandidate> {
         .iter()
         .map(|h| CompletionCandidate::new(&h.name).help(Some(h.endpoint().into())))
         .collect()
+}
+
+/// Completion candidates for a `--site` argument: each defined site's name. Best-effort.
+fn site_name_candidates() -> Vec<CompletionCandidate> {
+    let Ok(paths) = Paths::resolve() else {
+        return Vec::new();
+    };
+    let Ok(cfg) = Config::load(&paths.config_file()) else {
+        return Vec::new();
+    };
+    match store::load_hosts(&cfg.hosts_path(&paths)) {
+        Ok(file) => file
+            .sites
+            .iter()
+            .map(|s| CompletionCandidate::new(&s.name))
+            .collect(),
+        Err(_) => Vec::new(),
+    }
 }
 
 #[cfg(test)]
@@ -748,5 +910,48 @@ mod tests {
     fn host_candidates_from_lists_each_name() {
         let hosts = vec![Host::new("a", "h1"), Host::new("b", "h2")];
         assert_eq!(host_candidates_from(&hosts).len(), 2);
+    }
+
+    #[test]
+    fn add_parses_site_flag_and_sets_it() {
+        let c = Cli::try_parse_from([
+            "sshelf", "add", "web", "-H", "10.0.0.1", "--site", "prod-dc",
+        ])
+        .unwrap();
+        match c.command {
+            Some(Command::Add(a)) => {
+                assert_eq!(a.site.as_deref(), Some("prod-dc"));
+                assert!(a.has_args());
+                assert_eq!(a.into_host().unwrap().site.as_deref(), Some("prod-dc"));
+            }
+            _ => panic!("expected add"),
+        }
+    }
+
+    #[test]
+    fn sites_subcommand_parses() {
+        let c = Cli::try_parse_from(["sshelf", "sites"]).unwrap();
+        assert!(matches!(c.command, Some(Command::Sites { action: None })));
+
+        let c = Cli::try_parse_from([
+            "sshelf", "sites", "add", "dc1", "-u", "deploy", "-J", "b1,b2",
+        ])
+        .unwrap();
+        match c.command {
+            Some(Command::Sites {
+                action:
+                    Some(SitesAction::Add {
+                        name,
+                        user,
+                        jump_hosts,
+                        ..
+                    }),
+            }) => {
+                assert_eq!(name, "dc1");
+                assert_eq!(user.as_deref(), Some("deploy"));
+                assert_eq!(jump_hosts, vec!["b1", "b2"]);
+            }
+            _ => panic!("expected sites add"),
+        }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -28,6 +28,43 @@ impl AuthMethod {
     }
 }
 
+/// A named grouping that may also carry optional shared SSH defaults its member hosts inherit
+/// at connect time. Every setting is optional — a bare site (name only) is pure grouping.
+/// Auth is **not** inheritable; it stays per-host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Site {
+    /// The site's name; hosts reference it by this (see `Host::site`).
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    /// Default ProxyJump chain (the site's bastion).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub jump_hosts: Vec<String>,
+    /// Default identity files (only applied to key-auth members).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub identity_files: Vec<String>,
+}
+
+impl Site {
+    #[allow(dead_code)] // wired into the sites manager + `sshelf sites add` (M3/M4)
+    pub fn new(name: impl Into<String>) -> Self {
+        Site {
+            name: name.into(),
+            user: None,
+            port: None,
+            jump_hosts: Vec::new(),
+            identity_files: Vec::new(),
+        }
+    }
+}
+
+/// Case-insensitive lookup of a site by name.
+pub fn find_site<'a>(sites: &'a [Site], name: &str) -> Option<&'a Site> {
+    sites.iter().find(|s| s.name.eq_ignore_ascii_case(name))
+}
+
 /// A single saved host.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Host {
@@ -59,6 +96,10 @@ pub struct Host {
     /// Raw extra args appended verbatim (shlex-split). Escape hatch for anything unmodeled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra_args: Option<String>,
+    /// The [`Site`] this host belongs to, by name. Groups the host and supplies optional
+    /// inherited defaults; an undefined name degrades to pure grouping (no inheritance).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub site: Option<String>,
 }
 
 impl Host {
@@ -75,6 +116,7 @@ impl Host {
             jump_hosts: Vec::new(),
             tags: Vec::new(),
             extra_args: None,
+            site: None,
         }
     }
 
@@ -100,22 +142,53 @@ impl Host {
         )
     }
 
-    /// The haystack string used for fuzzy matching (name + endpoint + tags).
+    /// The haystack string used for fuzzy matching (name + endpoint + tags + site).
     pub fn search_haystack(&self) -> String {
         let mut s = format!("{} {}", self.name, self.endpoint());
         if !self.tags.is_empty() {
             s.push(' ');
             s.push_str(&self.tags.join(" "));
         }
+        if let Some(site) = &self.site {
+            s.push(' ');
+            s.push_str(site);
+        }
         s
+    }
+
+    /// A clone with the host's [`Site`] defaults filled in **only where this host leaves a
+    /// field unset** (the host always wins). Returns a plain clone when the host has no site,
+    /// or names a site that isn't defined (graceful degradation — pure grouping). The `id` is
+    /// preserved, so frecency/secrets still key correctly.
+    pub fn with_site_defaults(&self, sites: &[Site]) -> Host {
+        let mut h = self.clone();
+        let Some(site) = self.site.as_deref().and_then(|n| find_site(sites, n)) else {
+            return h;
+        };
+        if h.user.is_none() {
+            h.user = site.user.clone();
+        }
+        if h.port.is_none() {
+            h.port = site.port;
+        }
+        if h.jump_hosts.is_empty() {
+            h.jump_hosts = site.jump_hosts.clone();
+        }
+        if h.identity_files.is_empty() {
+            h.identity_files = site.identity_files.clone();
+        }
+        h
     }
 }
 
-/// The whole `hosts.toml` file. `format_version` is declared first so it serializes
-/// before the `[[host]]` array (TOML requires scalars before array-of-tables).
+/// The whole `hosts.toml` file. `format_version` (a scalar) is declared first so it serializes
+/// before the `[[site]]` / `[[host]]` arrays (TOML requires scalars before array-of-tables);
+/// `sites` comes before `hosts` so site definitions read at the top when hand-editing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HostsFile {
     pub format_version: u32,
+    #[serde(default, rename = "site", skip_serializing_if = "Vec::is_empty")]
+    pub sites: Vec<Site>,
     #[serde(default, rename = "host", skip_serializing_if = "Vec::is_empty")]
     pub hosts: Vec<Host>,
 }
@@ -126,6 +199,7 @@ impl Default for HostsFile {
     fn default() -> Self {
         HostsFile {
             format_version: CURRENT_FORMAT_VERSION,
+            sites: Vec::new(),
             hosts: Vec::new(),
         }
     }
@@ -154,5 +228,66 @@ mod tests {
     fn auth_serializes_lowercase() {
         let json = serde_json::to_string(&AuthMethod::Password).unwrap();
         assert_eq!(json, "\"password\"");
+    }
+
+    fn prod_site() -> Site {
+        Site {
+            name: "prod".into(),
+            user: Some("deploy".into()),
+            port: Some(2222),
+            jump_hosts: vec!["bastion".into()],
+            identity_files: vec!["/k".into()],
+        }
+    }
+
+    #[test]
+    fn site_defaults_fill_only_unset_fields() {
+        let sites = [prod_site()];
+
+        // A host that sets nothing inherits everything; the id is preserved.
+        let mut bare = Host::new("web", "10.0.0.1");
+        bare.site = Some("PROD".into()); // case-insensitive match
+        let eff = bare.with_site_defaults(&sites);
+        assert_eq!(eff.user.as_deref(), Some("deploy"));
+        assert_eq!(eff.port, Some(2222));
+        assert_eq!(eff.jump_hosts, vec!["bastion".to_string()]);
+        assert_eq!(eff.identity_files, vec!["/k".to_string()]);
+        assert_eq!(eff.id, bare.id);
+
+        // Per-host fields win; only the unset ones (here, port) inherit.
+        let mut own = Host::new("db", "10.0.0.2");
+        own.site = Some("prod".into());
+        own.user = Some("mike".into());
+        own.jump_hosts = vec!["own-jump".into()];
+        let eff = own.with_site_defaults(&sites);
+        assert_eq!(eff.user.as_deref(), Some("mike"));
+        assert_eq!(eff.jump_hosts, vec!["own-jump".to_string()]);
+        assert_eq!(eff.port, Some(2222));
+    }
+
+    #[test]
+    fn no_site_or_undefined_site_is_a_plain_clone() {
+        let sites = [prod_site()];
+        // site = None
+        assert_eq!(Host::new("a", "h").with_site_defaults(&sites).user, None);
+        // names a site that isn't defined → no inheritance, no panic
+        let mut dangling = Host::new("b", "h");
+        dangling.site = Some("ghost".into());
+        assert_eq!(dangling.with_site_defaults(&sites).user, None);
+    }
+
+    #[test]
+    fn find_site_is_case_insensitive() {
+        let sites = vec![Site::new("Prod-DC"), Site::new("staging")];
+        assert!(find_site(&sites, "prod-dc").is_some());
+        assert!(find_site(&sites, "PROD-DC").is_some());
+        assert!(find_site(&sites, "missing").is_none());
+    }
+
+    #[test]
+    fn haystack_includes_site() {
+        let mut h = Host::new("web", "10.0.0.1");
+        h.site = Some("prod-dc".into());
+        assert!(h.search_haystack().contains("prod-dc"));
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -20,17 +20,22 @@ pub fn matcher() -> Matcher {
     Matcher::new(Config::DEFAULT)
 }
 
-/// Split a query into `tag:` filters and the remaining fuzzy text.
-pub fn parse_query(query: &str) -> (Vec<String>, String) {
+/// Split a query into `tag:` filters, an optional single `site:` filter, and the remaining
+/// fuzzy text.
+pub fn parse_query(query: &str) -> (Vec<String>, Option<String>, String) {
     let mut tags = Vec::new();
+    let mut site: Option<String> = None;
     let mut rest: Vec<&str> = Vec::new();
     for tok in query.split_whitespace() {
-        match tok.strip_prefix("tag:") {
-            Some(t) if !t.is_empty() => tags.push(t.to_lowercase()),
-            _ => rest.push(tok),
+        if let Some(t) = tok.strip_prefix("tag:").filter(|t| !t.is_empty()) {
+            tags.push(t.to_lowercase());
+        } else if let Some(s) = tok.strip_prefix("site:").filter(|s| !s.is_empty()) {
+            site = Some(s.to_lowercase()); // single-valued: the last one wins
+        } else {
+            rest.push(tok);
         }
     }
-    (tags, rest.join(" "))
+    (tags, site, rest.join(" "))
 }
 
 /// Host indices (into `hosts`) in display order.
@@ -41,9 +46,11 @@ pub fn rank(
     decay: f64,
     sort: Sort,
 ) -> Vec<usize> {
-    let (tag_filters, fuzzy) = parse_query(query);
+    let (tag_filters, site_filter, fuzzy) = parse_query(query);
     let candidates: Vec<usize> = (0..hosts.len())
-        .filter(|&i| has_all_tags(&hosts[i], &tag_filters))
+        .filter(|&i| {
+            has_all_tags(&hosts[i], &tag_filters) && matches_site(&hosts[i], site_filter.as_deref())
+        })
         .collect();
 
     let fq = fuzzy.trim();
@@ -121,6 +128,15 @@ pub fn match_indices(text: &str, query: &str, matcher: &mut Matcher) -> Vec<u32>
 fn has_all_tags(h: &Host, tags: &[String]) -> bool {
     tags.iter()
         .all(|t| h.tags.iter().any(|ht| ht.to_lowercase() == *t))
+}
+
+/// `None` (no filter) matches everything; otherwise the host's site must equal `want`
+/// (case-insensitive). `want` is already lowercased by `parse_query`.
+fn matches_site(h: &Host, want: Option<&str>) -> bool {
+    match want {
+        None => true,
+        Some(w) => h.site.as_deref().is_some_and(|s| s.eq_ignore_ascii_case(w)),
+    }
 }
 
 /// Higher frecency first.
@@ -217,10 +233,25 @@ mod tests {
     }
 
     #[test]
-    fn parse_query_splits_tags_and_text() {
-        let (tags, rest) = parse_query("tag:prod web tag:db x");
+    fn parse_query_splits_tags_site_and_text() {
+        let (tags, site, rest) = parse_query("tag:prod web site:dc1 tag:db x");
         assert_eq!(tags, vec!["prod", "db"]);
+        assert_eq!(site.as_deref(), Some("dc1"));
         assert_eq!(rest, "web x");
+    }
+
+    #[test]
+    fn site_token_filters_case_insensitively() {
+        let mut a = Host::new("web1", "10.0.0.1");
+        a.site = Some("dc1".into());
+        let mut b = Host::new("web2", "10.0.0.2");
+        b.site = Some("dc2".into());
+        let plain = Host::new("plain", "10.0.0.3"); // no site
+        let hosts = vec![a, b, plain];
+        let state = FrecencyState::default();
+        let order = rank(&hosts, "site:DC1", &state, 0.2, Sort::Name);
+        let names: Vec<&str> = order.iter().map(|&i| hosts[i].name.as_str()).collect();
+        assert_eq!(names, vec!["web1"]);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -94,16 +94,39 @@ mod tests {
         b.port = Some(2222);
         b.auth = AuthMethod::Password;
 
+        let mut site = crate::model::Site::new("prod-dc");
+        site.user = Some("deploy".into());
+        site.jump_hosts = vec!["bastion".into()];
+        a.site = Some("prod-dc".into());
+
         let hf = HostsFile {
             format_version: crate::model::CURRENT_FORMAT_VERSION,
+            sites: vec![site.clone()],
             hosts: vec![a.clone(), b.clone()],
         };
 
         save_hosts(&path, &hf).unwrap();
         let loaded = load_hosts(&path).unwrap();
         assert_eq!(loaded, hf);
+        assert_eq!(loaded.sites[0], site);
         assert_eq!(loaded.hosts[0], a);
         assert_eq!(loaded.hosts[1], b);
+    }
+
+    #[test]
+    fn loads_pre_sites_file_without_a_sites_array() {
+        // An old hosts.toml (no [[site]], no host `site=`) must still load: sites default empty.
+        let dir = tmpdir();
+        let path = dir.join("hosts.toml");
+        std::fs::write(
+            &path,
+            "format_version = 1\n\n[[host]]\nid = \"01HOST\"\nname = \"web\"\nhostname = \"10.0.0.1\"\n",
+        )
+        .unwrap();
+        let loaded = load_hosts(&path).unwrap();
+        assert!(loaded.sites.is_empty());
+        assert_eq!(loaded.hosts.len(), 1);
+        assert_eq!(loaded.hosts[0].site, None);
     }
 
     #[test]

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -9,7 +9,7 @@ use super::centered;
 use crate::app::App;
 
 pub fn render(frame: &mut Frame, _app: &App) {
-    let area = centered(frame.area(), 58, 18);
+    let area = centered(frame.area(), 58, 21);
     frame.render_widget(Clear, area);
 
     let lines = vec![
@@ -20,13 +20,16 @@ pub fn render(frame: &mut Frame, _app: &App) {
         Line::from(""),
         Line::from("  type            filter the list (fuzzy)"),
         Line::from("  tag:NAME        filter by tag (combine with text)"),
+        Line::from("  site:NAME       filter by site"),
         Line::from("  ↑ / ↓  ^p / ^n  move selection"),
         Line::from("  ↵               connect"),
         Line::from("  ^a / ^e / ^d    add / edit / delete host"),
         Line::from("  ^y              yank the ssh command"),
+        Line::from("  ^t              transfer files (SFTP)"),
         Line::from("  ^o              import from ~/.ssh/config"),
         Line::from("  F1              this help"),
         Line::from("  F2              settings (config & hosts file)"),
+        Line::from("  F3              manage sites"),
         Line::from("  esc             clear query, then quit"),
         Line::from("  ^c              quit"),
         Line::from(""),

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -70,7 +70,7 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
         .fg(super::accent())
         .add_modifier(Modifier::BOLD);
     // Highlight only the fuzzy part of the query (not any `tag:` tokens).
-    let (_, fuzzy) = search::parse_query(&app.query);
+    let (_, _, fuzzy) = search::parse_query(&app.query);
 
     let items: Vec<ListItem> = app
         .order
@@ -137,7 +137,13 @@ mod tests {
             data_dir: std::env::temp_dir(),
             config_file_override: None,
         };
-        let mut app = App::new(hosts, FrecencyState::default(), Config::default(), paths);
+        let mut app = App::new(
+            hosts,
+            Vec::new(),
+            FrecencyState::default(),
+            Config::default(),
+            paths,
+        );
         app.query.push_str(query);
         app.recompute();
         app
@@ -195,6 +201,7 @@ mod tests {
         };
         let app = App::new(
             vec![prod_web, prod_db, bastion],
+            Vec::new(),
             FrecencyState::default(),
             Config::default(),
             paths,

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -1,5 +1,8 @@
 //! The main list screen: search box, host list with match highlighting, hint bar.
 
+use std::collections::HashMap;
+
+use nucleo_matcher::Matcher;
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -7,6 +10,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 
 use crate::app::App;
+use crate::model::Host;
 use crate::search;
 
 pub fn render(frame: &mut Frame, app: &App) {
@@ -69,22 +73,55 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
     let hl = Style::default()
         .fg(super::accent())
         .add_modifier(Modifier::BOLD);
-    // Highlight only the fuzzy part of the query (not any `tag:` tokens).
+    // Highlight only the fuzzy part of the query (not any `tag:`/`site:` tokens).
     let (_, _, fuzzy) = search::parse_query(&app.query);
 
-    let items: Vec<ListItem> = app
-        .order
-        .iter()
-        .map(|&i| {
+    // Idle → group hosts under site headers; filtering → a flat list with a site column.
+    // `app.selected` indexes `order` (hosts only); headers shift the ListState index, so we
+    // track the selected host's position among the rendered items.
+    let grouped = app.query.is_empty();
+    let mut items: Vec<ListItem> = Vec::new();
+    let mut selected_listidx = 0usize;
+
+    if grouped {
+        let header_style = Style::default().fg(Color::DarkGray);
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for &i in &app.order {
+            *counts.entry(section_key(&app.hosts[i])).or_default() += 1;
+        }
+        let mut prev: Option<String> = None;
+        for (pos, &i) in app.order.iter().enumerate() {
             let h = &app.hosts[i];
-            let mut text = format!("{:<width$}  {}", h.name, h.endpoint(), width = name_w);
-            if !h.tags.is_empty() {
-                text.push_str(&format!("  [{}]", h.tags.join(",")));
+            let key = section_key(h);
+            if prev.as_deref() != Some(key.as_str()) {
+                let n = counts.get(&key).copied().unwrap_or(0);
+                items.push(ListItem::new(Line::from(Span::styled(
+                    format!("── {} ({}) ──", section_display(h), n),
+                    header_style,
+                ))));
+                prev = Some(key);
             }
-            let indices = search::match_indices(&text, &fuzzy, &mut matcher);
-            ListItem::new(Line::from(super::highlight(&text, &indices, base, hl)))
-        })
-        .collect();
+            if pos == app.selected {
+                selected_listidx = items.len();
+            }
+            items.push(host_row(h, name_w, &fuzzy, &mut matcher, base, hl, false));
+        }
+    } else {
+        for (pos, &i) in app.order.iter().enumerate() {
+            if pos == app.selected {
+                selected_listidx = items.len();
+            }
+            items.push(host_row(
+                &app.hosts[i],
+                name_w,
+                &fuzzy,
+                &mut matcher,
+                base,
+                hl,
+                true,
+            ));
+        }
+    }
 
     let list = List::new(items)
         .block(block)
@@ -92,8 +129,44 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 
     let mut state = ListState::default();
-    state.select(Some(app.selected));
+    state.select(Some(selected_listidx));
     frame.render_stateful_widget(list, area, &mut state);
+}
+
+/// The section a host belongs to, for display (its site name, or `(no site)`).
+fn section_display(h: &Host) -> &str {
+    h.site.as_deref().unwrap_or("(no site)")
+}
+
+/// The case-insensitive section key (matches `app::group_order`'s grouping).
+fn section_key(h: &Host) -> String {
+    section_display(h).to_lowercase()
+}
+
+/// One host row: `name  user@host:port  [tags]`, fuzzy-highlighted, with an optional dim
+/// `·site·` column (shown only in the flat/filtered view, where there are no section headers).
+fn host_row(
+    h: &Host,
+    name_w: usize,
+    fuzzy: &str,
+    matcher: &mut Matcher,
+    base: Style,
+    hl: Style,
+    show_site: bool,
+) -> ListItem<'static> {
+    let mut text = format!("{:<width$}  {}", h.name, h.endpoint(), width = name_w);
+    if !h.tags.is_empty() {
+        text.push_str(&format!("  [{}]", h.tags.join(",")));
+    }
+    let indices = search::match_indices(&text, fuzzy, matcher);
+    let mut spans = super::highlight(&text, &indices, base, hl);
+    if show_site && let Some(site) = &h.site {
+        spans.push(Span::styled(
+            format!("  ·{site}·"),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+    ListItem::new(Line::from(spans))
 }
 
 fn render_hint(frame: &mut Frame, app: &App, area: Rect) {
@@ -169,6 +242,33 @@ mod tests {
         assert!(text.contains("prod-web"));
         assert!(text.contains("prod-db"));
         assert!(!text.contains("bastion"));
+    }
+
+    #[test]
+    fn idle_groups_under_site_headers() {
+        let mut app = app_with("");
+        app.hosts[0].site = Some("prod-dc".into());
+        app.hosts[1].site = Some("prod-dc".into());
+        app.recompute(); // bastion (idx 2) stays site-less
+        let text = draw(&app);
+        assert!(
+            text.contains("prod-dc"),
+            "expected a prod-dc section header"
+        );
+        assert!(text.contains("(no site)"), "expected a (no site) group");
+    }
+
+    #[test]
+    fn filtering_shows_the_site_column() {
+        let mut app = app_with("");
+        app.hosts[0].site = Some("prod-dc".into());
+        app.query.push_str("prod-web");
+        app.recompute();
+        let text = draw(&app);
+        assert!(
+            text.contains("·prod-dc·"),
+            "expected a ·site· column when filtering"
+        );
     }
 
     fn buffer_lines(buf: &ratatui::buffer::Buffer) -> Vec<String> {

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -177,7 +177,7 @@ fn render_hint(frame: &mut Frame, app: &App, area: Rect) {
         );
         return;
     }
-    let hint = "↵ connect  ^a add  ^e edit  ^d del  ^y yank  ^t transfer  ^o import  F1 help  F2 settings  esc quit";
+    let hint = "↵ connect  ^a add  ^e edit  ^d del  ^y yank  ^t transfer  ^o import  F1 help  F2 settings  F3 sites  esc quit";
     frame.render_widget(
         Paragraph::new(hint).style(Style::default().fg(Color::DarkGray)),
         area,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ mod browse;
 mod help;
 mod list;
 pub(crate) mod settings;
+pub(crate) mod sites;
 mod transfer;
 mod widgets;
 pub(crate) mod wizard;
@@ -80,6 +81,10 @@ pub fn render(frame: &mut Frame, app: &App) {
     }
     if let Some(s) = &app.settings {
         settings::render(frame, s);
+        return;
+    }
+    if let Some(m) = &app.sites_manager {
+        sites::render(frame, m);
         return;
     }
     list::render(frame, app);

--- a/src/ui/sites.rs
+++ b/src/ui/sites.rs
@@ -1,0 +1,528 @@
+//! The sites manager (F3): create / edit / delete sites and their optional shared SSH defaults.
+//!
+//! Two levels: a **list** of sites, and an inline **form** for one site (name + optional
+//! user/port/jump/identity). On save it returns the edited site list plus the name **renames**
+//! made while editing; the app applies those to member hosts and clears any host whose site no
+//! longer exists (so deletes self-heal).
+
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+
+use super::centered;
+use super::widgets::TextField;
+use crate::model::Site;
+
+/// Form fields, in display order: (label, placeholder).
+const FORM_FIELDS: [(&str, &str); 5] = [
+    ("Name", "required · the name hosts reference"),
+    ("User", "optional · default login for member hosts"),
+    ("Port", "optional · default SSH port"),
+    (
+        "Jump",
+        "optional · default ProxyJump (bastion), comma-separated",
+    ),
+    (
+        "Identity",
+        "optional · default key file(s), comma-separated",
+    ),
+];
+const LABEL_W: usize = 10;
+/// Columns before a field value: marker(2) + padded label + space(1).
+const VALUE_COL: u16 = 2 + LABEL_W as u16 + 1;
+
+pub enum SitesOutcome {
+    Continue,
+    Cancel,
+    /// Commit the edited site list. The app applies `renames` (old → new) to member hosts, then
+    /// clears any host whose site name is no longer defined.
+    Save {
+        sites: Vec<Site>,
+        renames: Vec<(String, String)>,
+    },
+}
+
+// `Form` carries a SiteForm (several TextFields) while the others are tiny; this is transient
+// per-manager state, never stored in bulk, so the size difference is fine.
+#[allow(clippy::large_enum_variant)]
+enum Mode {
+    List,
+    Form(SiteForm),
+    ConfirmDelete(usize),
+}
+
+pub struct SitesManager {
+    sites: Vec<Site>,
+    selected: usize,
+    mode: Mode,
+    /// Name changes made while editing, applied to member hosts on save.
+    renames: Vec<(String, String)>,
+}
+
+impl SitesManager {
+    pub fn new(sites: Vec<Site>) -> Self {
+        SitesManager {
+            sites,
+            selected: 0,
+            mode: Mode::List,
+            renames: Vec::new(),
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> SitesOutcome {
+        match self.mode {
+            Mode::List => self.on_list_key(key),
+            Mode::ConfirmDelete(_) => self.on_confirm_key(key),
+            Mode::Form(_) => self.on_form_key(key),
+        }
+    }
+
+    fn on_list_key(&mut self, key: KeyEvent) -> SitesOutcome {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        match (key.code, ctrl) {
+            (KeyCode::Esc, _) | (KeyCode::Char('c'), true) => return SitesOutcome::Cancel,
+            (KeyCode::Char('s'), true) => {
+                return SitesOutcome::Save {
+                    sites: std::mem::take(&mut self.sites),
+                    renames: std::mem::take(&mut self.renames),
+                };
+            }
+            (KeyCode::Down, false) | (KeyCode::Char('n'), true) => {
+                if !self.sites.is_empty() && self.selected + 1 < self.sites.len() {
+                    self.selected += 1;
+                }
+            }
+            (KeyCode::Up, false) | (KeyCode::Char('p'), true) => {
+                self.selected = self.selected.saturating_sub(1);
+            }
+            (KeyCode::Char('a'), false) => self.mode = Mode::Form(SiteForm::new_add()),
+            (KeyCode::Char('e'), false) | (KeyCode::Enter, _) => {
+                if let Some(s) = self.sites.get(self.selected) {
+                    self.mode = Mode::Form(SiteForm::edit(self.selected, s));
+                }
+            }
+            (KeyCode::Char('d'), false) if self.selected < self.sites.len() => {
+                self.mode = Mode::ConfirmDelete(self.selected);
+            }
+            _ => {}
+        }
+        SitesOutcome::Continue
+    }
+
+    fn on_confirm_key(&mut self, key: KeyEvent) -> SitesOutcome {
+        let Mode::ConfirmDelete(idx) = self.mode else {
+            return SitesOutcome::Continue;
+        };
+        if matches!(key.code, KeyCode::Char('y') | KeyCode::Char('Y')) && idx < self.sites.len() {
+            self.sites.remove(idx); // member hosts are orphan-cleared by the app on save
+            if self.selected >= self.sites.len() {
+                self.selected = self.sites.len().saturating_sub(1);
+            }
+        }
+        self.mode = Mode::List;
+        SitesOutcome::Continue
+    }
+
+    fn on_form_key(&mut self, key: KeyEvent) -> SitesOutcome {
+        // Take the form out so we can freely mutate `self` while applying it.
+        let Mode::Form(mut form) = std::mem::replace(&mut self.mode, Mode::List) else {
+            return SitesOutcome::Continue;
+        };
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        if key.code == KeyCode::Esc {
+            return SitesOutcome::Continue; // discard; back to the list
+        }
+        let last = FORM_FIELDS.len() - 1;
+        let commit = (ctrl && key.code == KeyCode::Char('s'))
+            || (key.code == KeyCode::Enter && form.focus >= last);
+        if commit {
+            match form.build(&self.sites) {
+                Ok(site) => {
+                    self.apply_form(&form, site);
+                    return SitesOutcome::Continue; // mode already List
+                }
+                Err(e) => {
+                    form.error = Some(e);
+                    self.mode = Mode::Form(form);
+                    return SitesOutcome::Continue;
+                }
+            }
+        }
+        match key.code {
+            KeyCode::Tab | KeyCode::Down => form.focus = (form.focus + 1) % FORM_FIELDS.len(),
+            KeyCode::BackTab | KeyCode::Up => {
+                form.focus = (form.focus + FORM_FIELDS.len() - 1) % FORM_FIELDS.len()
+            }
+            KeyCode::Enter => form.focus += 1, // not last (commit handled that)
+            code => {
+                form.field_mut(form.focus).handle(code);
+            }
+        }
+        self.mode = Mode::Form(form);
+        SitesOutcome::Continue
+    }
+
+    /// Store a built site back into the list (recording a rename if its name changed on edit).
+    fn apply_form(&mut self, form: &SiteForm, site: Site) {
+        match form.editing {
+            Some(idx) => {
+                if let Some(orig) = &form.original_name
+                    && !orig.eq_ignore_ascii_case(&site.name)
+                {
+                    self.renames.push((orig.clone(), site.name.clone()));
+                }
+                if idx < self.sites.len() {
+                    self.sites[idx] = site;
+                    self.selected = idx;
+                }
+            }
+            None => {
+                self.sites.push(site);
+                self.selected = self.sites.len() - 1;
+            }
+        }
+    }
+}
+
+struct SiteForm {
+    /// Index being edited, or `None` for a new site.
+    editing: Option<usize>,
+    original_name: Option<String>,
+    focus: usize,
+    fields: [TextField; 5],
+    error: Option<String>,
+}
+
+impl SiteForm {
+    fn new_add() -> Self {
+        SiteForm {
+            editing: None,
+            original_name: None,
+            focus: 0,
+            fields: std::array::from_fn(|_| TextField::new()),
+            error: None,
+        }
+    }
+
+    fn edit(idx: usize, s: &Site) -> Self {
+        SiteForm {
+            editing: Some(idx),
+            original_name: Some(s.name.clone()),
+            focus: 0,
+            fields: [
+                TextField::with(&s.name),
+                TextField::with(s.user.clone().unwrap_or_default()),
+                TextField::with(s.port.map(|p| p.to_string()).unwrap_or_default()),
+                TextField::with(s.jump_hosts.join(", ")),
+                TextField::with(s.identity_files.join(", ")),
+            ],
+            error: None,
+        }
+    }
+
+    fn field(&self, i: usize) -> &TextField {
+        &self.fields[i]
+    }
+    fn field_mut(&mut self, i: usize) -> &mut TextField {
+        &mut self.fields[i]
+    }
+
+    /// Validate + build a `Site`. `existing` is the working list (to reject a duplicate name).
+    fn build(&self, existing: &[Site]) -> Result<Site, String> {
+        let name = self.fields[0].value.trim().to_string();
+        if name.is_empty() {
+            return Err("Name is required".into());
+        }
+        let dup = existing
+            .iter()
+            .enumerate()
+            .any(|(i, s)| Some(i) != self.editing && s.name.eq_ignore_ascii_case(&name));
+        if dup {
+            return Err(format!("a site named '{name}' already exists"));
+        }
+        let port = {
+            let t = self.fields[2].value.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(
+                    t.parse::<u16>()
+                        .map_err(|_| "Port must be a number 1-65535".to_string())?,
+                )
+            }
+        };
+        Ok(Site {
+            name,
+            user: opt(&self.fields[1].value),
+            port,
+            jump_hosts: split_list(&self.fields[3].value),
+            identity_files: split_list(&self.fields[4].value),
+        })
+    }
+}
+
+fn opt(s: &str) -> Option<String> {
+    let t = s.trim();
+    (!t.is_empty()).then(|| t.to_string())
+}
+
+fn split_list(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(str::trim)
+        .filter(|x| !x.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// A one-line summary of a site's defaults (dim when it carries none).
+fn summary(s: &Site) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(u) = &s.user {
+        parts.push(format!("user {u}"));
+    }
+    if let Some(p) = s.port {
+        parts.push(format!("port {p}"));
+    }
+    if !s.jump_hosts.is_empty() {
+        parts.push(format!("-J {}", s.jump_hosts.join(",")));
+    }
+    if !s.identity_files.is_empty() {
+        parts.push(format!("-i {}", s.identity_files.len()));
+    }
+    if parts.is_empty() {
+        "(grouping only)".to_string()
+    } else {
+        parts.join("  ")
+    }
+}
+
+pub fn render(frame: &mut Frame, m: &SitesManager) {
+    let area = centered(
+        frame.area(),
+        frame.area().width.saturating_sub(6).clamp(50, 90),
+        18,
+    );
+    frame.render_widget(Clear, area);
+    let block = Block::default().borders(Borders::ALL).title(" sites ");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    match &m.mode {
+        Mode::Form(form) => render_form(frame, inner, form),
+        _ => render_list(frame, inner, m),
+    }
+}
+
+fn render_list(frame: &mut Frame, area: Rect, m: &SitesManager) {
+    let accent = Style::default().fg(super::accent());
+    let dim = Style::default().fg(Color::DarkGray);
+
+    let rows = ratatui::layout::Layout::vertical([
+        ratatui::layout::Constraint::Min(0),
+        ratatui::layout::Constraint::Length(1),
+    ])
+    .split(area);
+
+    if m.sites.is_empty() {
+        frame.render_widget(
+            Paragraph::new("no sites yet — press a to add one").style(dim),
+            rows[0],
+        );
+    } else {
+        let name_w = m
+            .sites
+            .iter()
+            .map(|s| s.name.chars().count())
+            .max()
+            .unwrap_or(0)
+            .clamp(6, 20);
+        let items: Vec<ListItem> = m
+            .sites
+            .iter()
+            .map(|s| {
+                ListItem::new(Line::from(vec![
+                    Span::raw(format!("{:<name_w$}  ", s.name)),
+                    Span::styled(summary(s), dim),
+                ]))
+            })
+            .collect();
+        let list = List::new(items)
+            .highlight_symbol("▸ ")
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+        let mut state = ListState::default();
+        state.select(Some(m.selected.min(m.sites.len().saturating_sub(1))));
+        frame.render_stateful_widget(list, rows[0], &mut state);
+    }
+
+    let hint = match &m.mode {
+        Mode::ConfirmDelete(idx) => {
+            let name = m.sites.get(*idx).map(|s| s.name.as_str()).unwrap_or("");
+            return frame.render_widget(
+                Paragraph::new(format!(
+                    "delete '{name}'? y = delete · any other key = cancel"
+                ))
+                .style(Style::default().fg(Color::Red)),
+                rows[1],
+            );
+        }
+        _ => "a add · e/↵ edit · d delete · ^s save · esc cancel",
+    };
+    frame.render_widget(Paragraph::new(hint).style(accent), rows[1]);
+}
+
+fn render_form(frame: &mut Frame, area: Rect, form: &SiteForm) {
+    let accent = Style::default()
+        .fg(super::accent())
+        .add_modifier(Modifier::BOLD);
+    let dim = Style::default().fg(Color::DarkGray);
+
+    for (row, (label, placeholder)) in FORM_FIELDS.iter().enumerate() {
+        let focused = row == form.focus;
+        let marker = if focused { "▸ " } else { "  " };
+        let label_style = if focused { accent } else { Style::default() };
+        let tf = form.field(row);
+        let (value, is_placeholder) = if tf.value.is_empty() {
+            ((*placeholder).to_string(), true)
+        } else {
+            (tf.value.clone(), false)
+        };
+        let value_style = if is_placeholder {
+            dim
+        } else {
+            Style::default()
+        };
+        let line = Line::from(vec![
+            Span::styled(marker, accent),
+            Span::styled(format!("{label:<LABEL_W$} "), label_style),
+            Span::styled(value, value_style),
+        ]);
+        frame.render_widget(
+            Paragraph::new(line),
+            Rect {
+                x: area.x,
+                y: area.y + row as u16,
+                width: area.width,
+                height: 1,
+            },
+        );
+    }
+
+    let y = area.y + FORM_FIELDS.len() as u16 + 1;
+    if let Some(err) = &form.error {
+        frame.render_widget(
+            Paragraph::new(format!("⚠ {err}")).style(Style::default().fg(Color::Red)),
+            Rect {
+                x: area.x,
+                y,
+                width: area.width,
+                height: 1,
+            },
+        );
+    }
+    frame.render_widget(
+        Paragraph::new("Tab/↑↓ move · ↵ next (saves on last) · ^s save · esc back").style(dim),
+        Rect {
+            x: area.x,
+            y: y + 1,
+            width: area.width,
+            height: 1,
+        },
+    );
+
+    // Cursor on the focused field.
+    let tf = form.field(form.focus);
+    let cx = area.x + VALUE_COL + tf.cursor as u16;
+    let cx = cx.min(area.x + area.width.saturating_sub(1));
+    frame.set_cursor_position((cx, area.y + form.focus as u16));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn k(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+    fn ctrl(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::CONTROL)
+    }
+    fn type_str(m: &mut SitesManager, s: &str) {
+        for c in s.chars() {
+            m.handle_key(k(KeyCode::Char(c)));
+        }
+    }
+
+    #[test]
+    fn add_a_site_with_defaults() {
+        let mut m = SitesManager::new(vec![]);
+        m.handle_key(k(KeyCode::Char('a'))); // open the add form (Name focused)
+        type_str(&mut m, "prod-dc");
+        m.handle_key(k(KeyCode::Down)); // → User
+        type_str(&mut m, "deploy");
+        m.handle_key(ctrl(KeyCode::Char('s'))); // commit the form
+        match m.handle_key(ctrl(KeyCode::Char('s'))) {
+            // save the manager
+            SitesOutcome::Save { sites, renames } => {
+                assert_eq!(sites.len(), 1);
+                assert_eq!(sites[0].name, "prod-dc");
+                assert_eq!(sites[0].user.as_deref(), Some("deploy"));
+                assert!(renames.is_empty());
+            }
+            _ => panic!("expected save"),
+        }
+    }
+
+    #[test]
+    fn editing_the_name_records_a_rename() {
+        let mut m = SitesManager::new(vec![Site::new("old")]);
+        m.handle_key(k(KeyCode::Enter)); // edit selected (Name focused, value "old")
+        // clear "old" and type "new"
+        for _ in 0..3 {
+            m.handle_key(k(KeyCode::Backspace));
+        }
+        type_str(&mut m, "new");
+        m.handle_key(ctrl(KeyCode::Char('s'))); // commit
+        match m.handle_key(ctrl(KeyCode::Char('s'))) {
+            SitesOutcome::Save { sites, renames } => {
+                assert_eq!(sites[0].name, "new");
+                assert_eq!(renames, vec![("old".to_string(), "new".to_string())]);
+            }
+            _ => panic!("expected save"),
+        }
+    }
+
+    #[test]
+    fn delete_needs_confirmation() {
+        let mut m = SitesManager::new(vec![Site::new("a"), Site::new("b")]);
+        m.handle_key(k(KeyCode::Char('d'))); // confirm prompt for "a"
+        m.handle_key(k(KeyCode::Char('n'))); // any non-y cancels
+        assert_eq!(m.sites.len(), 2);
+        m.handle_key(k(KeyCode::Char('d')));
+        m.handle_key(k(KeyCode::Char('y'))); // confirm
+        assert_eq!(m.sites.len(), 1);
+        assert_eq!(m.sites[0].name, "b");
+    }
+
+    #[test]
+    fn rejects_a_duplicate_name() {
+        let mut m = SitesManager::new(vec![Site::new("dup")]);
+        m.handle_key(k(KeyCode::Char('a')));
+        type_str(&mut m, "DUP"); // case-insensitive clash
+        m.handle_key(ctrl(KeyCode::Char('s')));
+        // The form stays open with an error; the site list is unchanged.
+        assert!(matches!(m.mode, Mode::Form(_)));
+        assert_eq!(m.sites.len(), 1);
+    }
+
+    #[test]
+    fn esc_from_list_cancels() {
+        let mut m = SitesManager::new(vec![Site::new("a")]);
+        assert!(matches!(
+            m.handle_key(k(KeyCode::Esc)),
+            SitesOutcome::Cancel
+        ));
+    }
+}

--- a/src/ui/wizard.rs
+++ b/src/ui/wizard.rs
@@ -39,6 +39,7 @@ enum Field {
     Secret,
     JumpHosts,
     Tags,
+    Site,
     ExtraArgs,
 }
 
@@ -60,6 +61,7 @@ impl Field {
             }
             Field::JumpHosts => "Jump hosts",
             Field::Tags => "Tags",
+            Field::Site => "Site",
             Field::ExtraArgs => "Extra args",
         }
     }
@@ -81,6 +83,7 @@ impl Field {
             }
             Field::JumpHosts => "optional · ProxyJump chain, e.g. bastion,host2",
             Field::Tags => "optional · labels, space/comma separated, e.g. prod db",
+            Field::Site => "←/→ choose a site · (none) = no site · manage with F3",
             Field::ExtraArgs => "optional · extra ssh flags, e.g. -o BatchMode=yes",
         }
     }
@@ -149,6 +152,63 @@ impl KeyPicker {
     }
 }
 
+/// The "no site" sentinel shown first in the [`SitePicker`].
+const NO_SITE: &str = "(none)";
+
+/// A chooser over `(none)` + the defined site names (cycled with ←/→).
+struct SitePicker {
+    options: Vec<String>, // options[0] is the NO_SITE sentinel
+    idx: usize,
+}
+
+impl SitePicker {
+    fn new(site_names: &[String], preselect: Option<&str>) -> Self {
+        let mut options = vec![NO_SITE.to_string()];
+        options.extend(site_names.iter().cloned());
+        // Editing a host whose site isn't (or no longer is) in the defined set: keep it as an
+        // option so saving doesn't silently drop the assignment.
+        if let Some(p) = preselect
+            && !p.is_empty()
+            && !options.iter().any(|o| o.eq_ignore_ascii_case(p))
+        {
+            options.push(p.to_string());
+        }
+        let idx = preselect
+            .filter(|p| !p.is_empty())
+            .and_then(|p| options.iter().position(|o| o.eq_ignore_ascii_case(p)))
+            .unwrap_or(0);
+        SitePicker { options, idx }
+    }
+
+    /// The chosen site name, or `None` for "(none)".
+    fn selected(&self) -> Option<&str> {
+        match self.options.get(self.idx).map(String::as_str) {
+            Some(NO_SITE) => None,
+            other => other,
+        }
+    }
+
+    fn prev(&mut self) {
+        if !self.options.is_empty() {
+            self.idx = (self.idx + self.options.len() - 1) % self.options.len();
+        }
+    }
+    fn next(&mut self) {
+        if !self.options.is_empty() {
+            self.idx = (self.idx + 1) % self.options.len();
+        }
+    }
+
+    fn display(&self) -> String {
+        let cur = self
+            .options
+            .get(self.idx)
+            .map(String::as_str)
+            .unwrap_or(NO_SITE);
+        format!("< {cur} >    ({}/{})", self.idx + 1, self.options.len())
+    }
+}
+
 // Save carries a Host (large) while the others are unit variants; this enum is a transient
 // return value, never stored, so the size difference is fine.
 #[allow(clippy::large_enum_variant)]
@@ -179,6 +239,7 @@ pub struct Wizard {
     secret: TextField,
     jump: TextField,
     tags: TextField,
+    site: SitePicker,
     extra: TextField,
     /// File browser modal, open when the user is picking a key file.
     browser: Option<FileBrowser>,
@@ -186,16 +247,23 @@ pub struct Wizard {
 }
 
 impl Wizard {
-    pub fn new_add() -> Self {
-        Self::build(None, AuthMethod::Agent, discover_ssh_keys(), None)
+    pub fn new_add(site_names: &[String]) -> Self {
+        Self::build(
+            None,
+            AuthMethod::Agent,
+            discover_ssh_keys(),
+            None,
+            site_names,
+        )
     }
 
-    pub fn from_host(h: &Host) -> Self {
+    pub fn from_host(h: &Host, site_names: &[String]) -> Self {
         let mut w = Self::build(
             Some(h.id.clone()),
             h.auth,
             discover_ssh_keys(),
             h.identity_files.first().map(String::as_str),
+            site_names,
         );
         w.name = TextField::with(&h.name);
         w.hostname = TextField::with(&h.hostname);
@@ -203,6 +271,7 @@ impl Wizard {
         w.port = TextField::with(h.port.map(|p| p.to_string()).unwrap_or_default());
         w.jump = TextField::with(h.jump_hosts.join(", "));
         w.tags = TextField::with(h.tags.join(", "));
+        w.site = SitePicker::new(site_names, h.site.as_deref());
         w.extra = TextField::with(h.extra_args.clone().unwrap_or_default());
         w.extra_identities = h.identity_files.iter().skip(1).cloned().collect();
         // secret stays blank on edit (blank = keep existing)
@@ -214,6 +283,7 @@ impl Wizard {
         auth: AuthMethod,
         keys: Vec<String>,
         preselect: Option<&str>,
+        site_names: &[String],
     ) -> Self {
         Wizard {
             editing_id,
@@ -228,6 +298,7 @@ impl Wizard {
             secret: TextField::new(),
             jump: TextField::new(),
             tags: TextField::new(),
+            site: SitePicker::new(site_names, None),
             extra: TextField::new(),
             browser: None,
             error: None,
@@ -255,7 +326,7 @@ impl Wizard {
             AuthMethod::Password => v.push(Field::Secret),
             AuthMethod::Agent => {}
         }
-        v.extend([Field::JumpHosts, Field::Tags, Field::ExtraArgs]);
+        v.extend([Field::JumpHosts, Field::Tags, Field::Site, Field::ExtraArgs]);
         v
     }
 
@@ -269,7 +340,7 @@ impl Wizard {
             Field::JumpHosts => Some(&mut self.jump),
             Field::Tags => Some(&mut self.tags),
             Field::ExtraArgs => Some(&mut self.extra),
-            Field::Auth | Field::Identity => None,
+            Field::Auth | Field::Identity | Field::Site => None,
         }
     }
 
@@ -283,7 +354,7 @@ impl Wizard {
             Field::JumpHosts => Some(&self.jump),
             Field::Tags => Some(&self.tags),
             Field::ExtraArgs => Some(&self.extra),
-            Field::Auth | Field::Identity => None,
+            Field::Auth | Field::Identity | Field::Site => None,
         }
     }
 
@@ -331,6 +402,11 @@ impl Wizard {
                 Field::Identity => match code {
                     KeyCode::Left => self.identity.prev(),
                     KeyCode::Right | KeyCode::Char(' ') => self.identity.next(),
+                    _ => {}
+                },
+                Field::Site => match code {
+                    KeyCode::Left => self.site.prev(),
+                    KeyCode::Right | KeyCode::Char(' ') => self.site.next(),
                     _ => {}
                 },
                 f => {
@@ -410,6 +486,7 @@ impl Wizard {
         };
         h.jump_hosts = split_list(&self.jump.value);
         h.tags = split_tags(&self.tags.value);
+        h.site = self.site.selected().map(str::to_string);
         let extra = self.extra.value.trim();
         h.extra_args = (!extra.is_empty()).then(|| extra.to_string());
 
@@ -619,6 +696,7 @@ fn field_value(w: &Wizard, field: Field) -> (String, bool) {
             false,
         ),
         Field::Identity => (w.identity.display(), w.identity.selected().is_none()),
+        Field::Site => (w.site.display(), w.site.selected().is_none()),
         Field::Secret => {
             let n = w.secret.value.chars().count();
             if n == 0 {
@@ -653,6 +731,7 @@ mod tests {
             AuthMethod::Agent,
             keys.iter().map(|s| s.to_string()).collect(),
             None,
+            &[],
         )
     }
 
@@ -749,6 +828,30 @@ mod tests {
     }
 
     #[test]
+    fn site_chooser_selects_and_saves() {
+        let sites = vec!["prod-dc".to_string(), "staging".to_string()];
+        let mut w = Wizard::build(None, AuthMethod::Agent, vec![], None, &sites);
+        type_str(&mut w, "n");
+        goto(&mut w, Field::Hostname);
+        type_str(&mut w, "h");
+        goto(&mut w, Field::Site);
+        w.handle_key(k(KeyCode::Right)); // (none) -> prod-dc
+        match w.try_save() {
+            WizardOutcome::Save { host, .. } => assert_eq!(host.site.as_deref(), Some("prod-dc")),
+            _ => panic!("expected save"),
+        }
+    }
+
+    #[test]
+    fn from_host_preselects_the_site() {
+        let sites = vec!["prod-dc".to_string()];
+        let mut h = Host::new("web", "h");
+        h.site = Some("prod-dc".into());
+        let w = Wizard::from_host(&h, &sites);
+        assert_eq!(w.site.selected(), Some("prod-dc"));
+    }
+
+    #[test]
     fn requires_name_and_hostname() {
         let mut w = with_keys(&[]);
         assert!(matches!(w.try_save(), WizardOutcome::Continue));
@@ -771,7 +874,7 @@ mod tests {
         let mut h = Host::new("multi", "host");
         h.auth = AuthMethod::Key;
         h.identity_files = vec!["/keys/a".into(), "/keys/b".into()];
-        let mut w = Wizard::from_host(&h);
+        let mut w = Wizard::from_host(&h, &[]);
         // Don't touch the picker; just save.
         match w.try_save() {
             WizardOutcome::Save { host, .. } => {
@@ -788,7 +891,7 @@ mod tests {
     fn edit_preserves_id() {
         let mut h = Host::new("old", "host");
         h.user = Some("me".into());
-        let mut w = Wizard::from_host(&h);
+        let mut w = Wizard::from_host(&h, &[]);
         match w.try_save() {
             WizardOutcome::Save { host, .. } => {
                 assert_eq!(host.id, h.id);


### PR DESCRIPTION
**Sites**: group hosts (one site per host, e.g. a data center / project), distinct from the
  many-valued free-form tags.
A site can carry **optional** shared SSH defaults: user, port, ProxyJump (bastion), identity; that member hosts inherit at connect time where the host leaves a field unset (the host always wins; auth stays per-host).
The list **groups by site** when idle and shows a `·site·` column + `site:NAME` filter while typing. Manage sites with **F3** (create/edit/delete + their defaults); assign one in the add/edit form. 
CLI: `sshelf sites [--json]`, `sshelf sites add NAME [-u/-p/-J/-i]`, and `sshelf add --site NAME`. 

Stored in `hosts.toml` as `[[site]]`
old files load unchanged.