### PR TITLE
Add background port forwarding (Ctrl-f to create, F4 to manage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ versions follow SemVer.
 
 ## [Unreleased]
 
+### Added
+- **Background port forwarding** (`Ctrl-f` on a host): a popup to start a **Local** (`-L`),
+  **Remote** (`-R`) or **Dynamic** (`-D` SOCKS) SSH tunnel, reusing the host's auth exactly as
+  connect does (keys / agent / ProxyJump / stored password, plus site defaults). The forward runs
+  as a detached background process that **keeps running after you quit sshelf**, and a bind/auth
+  failure (port in use, privileged port, server refused) is reported in the popup. A new
+  **forwards manager** (`F4`) lists every active forward across hosts with its pid and age and
+  stops any (`d`/`k` → `y`); the list refreshes live and is reconciled against the running
+  processes on each launch, so it only ever shows forwards that are still actually running.
+  Tracked in `forwards.json`. No new dependencies.
+
 ## [0.6.0] — 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ your editor, and adds things plain SSH config can't express as nicely:
 - **Dual-pane file transfer** (`Ctrl-t`) — a two-pane browser to copy files and folders to and
   from a host over SFTP/SCP, with fuzzy search on both sides and live progress. It authenticates
   once (reusing the host's keys/agent or stored password) and never touches `~/.ssh/config`.
+- **Background port forwarding** (`Ctrl-f`) — start a Local (`-L`), Remote (`-R`) or Dynamic
+  (`-D` SOCKS) SSH tunnel that **keeps running after you quit sshelf**. A manager screen (`F4`)
+  lists every active forward and stops any; they're reconciled against the OS on each launch.
 - **Guided add/edit form** — hostname, user, port, auth, jump hosts, tags, site, extra args.
 - **Sites** (`F3`) — group hosts (one per host, e.g. a data center) and optionally give the site
   a **shared bastion + default user/port/key** that members inherit at connect time. The list
@@ -99,7 +102,8 @@ echo "$PASS" | sshelf set-password <name>   # store a password (scriptable / hea
 
 **Keys:** type to filter · `tag:NAME` / `site:NAME` to filter · `↑/↓` move · `Enter` connect ·
 `Ctrl-a` add · `Ctrl-e` edit · `Ctrl-d` delete · `Ctrl-y` yank the `ssh` command · `Ctrl-t`
-transfer files · `Ctrl-o` import · `F1` help · `F2` settings · `F3` sites · `Esc`/`Ctrl-c` quit.
+transfer files · `Ctrl-f` port-forward · `Ctrl-o` import · `F1` help · `F2` settings · `F3` sites ·
+`F4` forwards · `Esc`/`Ctrl-c` quit.
 
 In the **add/edit** form the Key field picks an identity: `←/→` cycles keys found in `~/.ssh`
 (including `.pem`), and `Enter` opens a file browser (type to fuzzy-filter) to choose a key

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -11,6 +11,7 @@ config hand-editable instead of buried in macOS `~/Library`.
 | `hosts.toml` | `~/.config/sshelf/hosts.toml` | user | The host database. Human-editable. |
 | `config.toml` | `~/.config/sshelf/config.toml` | user | Preferences (theme, `decay_rate`, sort, keybinds). |
 | `state.json` | `~/.local/share/sshelf/state.json` | app | Frecency counters, keyed by host id. Churns; not for hand-editing. |
+| `forwards.json` | `~/.local/share/sshelf/forwards.json` | app | Ledger of active background port-forwards (PIDs). Reconciled against the OS on launch. Mode `0600`. |
 | `vault.age` | `~/.local/share/sshelf/vault.age` | app | **Fallback** encrypted secret store (only when no OS keyring). Mode `0600`. |
 
 Directories are created on first run (`0700`). **Secrets are never written to `hosts.toml`.**
@@ -72,6 +73,30 @@ deleting one clears members' `site`. See [`decisions.md`](./decisions.md) D-020.
 - Kept separate from `hosts.toml` so the user-owned host file stays stable and diff-friendly.
 - Score: `use_count * exp(-decay_rate * days_since_last_used)` (`decay_rate` default `0.2`).
   See [`ux.md`](./ux.md) for how it combines with fuzzy ranking.
+
+## Port-forward ledger (`forwards.json`)
+
+```json
+[
+  {
+    "id": "01J…",                       // ULID; also names the forward's stderr log
+    "host_id": "01J…",                  // originating host id
+    "host_name": "prod-db",             // snapshot for display
+    "kind": "local",                    // "local" | "remote" | "dynamic"
+    "spec": { "listen_port": 8080, "target_host": "db", "target_port": 3306 },
+    "display": "L  127.0.0.1:8080 → db:3306",
+    "pid": 41234,                       // the detached `ssh -N` process
+    "started_at": 1718900000
+  }
+]
+```
+
+- App-owned; written atomically (`0600`). The running `ssh` processes are authoritative — this
+  file is only a remembered list of PIDs, **reconciled** against the OS (`ps`) on startup, on
+  opening the manager, and each tick while it's open. A forward leaves the ledger the moment its
+  process is gone, however it ended. See [`decisions.md`](./decisions.md) D-021.
+- `spec` omits empty fields (`bind` defaults to `127.0.0.1`, `target_host` to `localhost`);
+  Dynamic forwards carry only `listen_port`.
 
 ## Secrets
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,6 +5,36 @@ whenever you make a non-trivial design choice.
 
 ---
 
+### D-021 · Port forwards are detached `ssh -N` processes tracked by PID
+Background port forwards (`Ctrl-f` popup, `F4` manager) must keep running after sshelf exits.
+Each forward is **one detached `ssh -N -L|-R|-D <spec>` process**, reusing `ssh::build_args` +
+`ssh::configure_askpass` (so keys/agent/ProxyJump/stored-password and site defaults all work as
+connect does). It is spawned with `std::os::unix::process::CommandExt::process_group(0)` (std,
+**no new dep**) and null stdin/stdout, which makes it survive both sshelf exiting (orphaned →
+reparented to init) and the terminal closing (its own process group never receives the shell's
+SIGHUP). **Nothing kills a forward on `Drop` or app shutdown** — that is what keeps it alive.
+Validated by an M0 spike: a `process_group(0)` child with null stdio outlives its spawner
+(PPID→1) in its own process group, and `kill -TERM` stops it.
+
+There is no daemon. The running processes are the source of truth; `forwards.json` (mirrors
+`state.json`: `#[serde(transparent)]` over a `Vec`, `atomic_write` `0600`) is just a remembered
+list of PIDs. `reconcile` re-validates each PID via `ps -ww -o state=,command=`: a forward stays
+only if the process exists, isn't a zombie (`state != Z` — so a dead-but-unreaped child we
+spawned this session is correctly seen as gone), **and** its command line still matches our
+`ssh … <spec>` (a **PID-reuse guard** — a recycled pid is never counted alive or signalled).
+Reconcile runs on startup, on opening the manager, and on the ~100ms event-loop tick while it's
+open. Readiness/errors: `-o ExitOnForwardFailure=yes` makes ssh exit non-zero on a bind failure;
+spawn polls `try_wait` for ~2.5s and, on an early exit, maps the stderr (captured to a temp file,
+not a pipe, so a long-lived ssh never gets SIGPIPE) to a friendly message (port in use,
+privileged port, server refused, auth failed). A third kind, **Dynamic** (`-D` SOCKS), was added
+alongside Local/Remote. Rejected: a worker thread per forward (the transfer model — unneeded, a
+forward has no ongoing protocol to service, just liveness); holding the `Child` for `try_wait`
+(can't track forwards from a previous session, and splits liveness into two code paths); `ssh -f`
+(clean daemonize but hides the real PID, breaking the reuse guard and individual kill);
+`libc::setsid`/`nix::kill` (a new dep the project avoids — `process_group(0)` + shelling to
+`ps`/`kill`, as we already shell to `ssh`/`sftp`, is dep-free); kill-only for v1 (restart of a
+dropped forward is deferred — the spec is persisted, so it's an easy fast-follow).
+
 ### D-020 · Sites: one-per-host grouping with optional inherited SSH defaults
 Hosts can belong to a **Site** (a data center / project), distinct from many-valued free-form
 `tags`. A site is **one per host** and may carry **optional** shared SSH defaults — `user`,

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -3,8 +3,27 @@
 Reverse-chronological. Newest entry on top. Every change to the project adds an entry here
 (the docs-in-sync rule). Keep entries short: what changed, why, and what's next.
 
-**Current milestone:** Sites — group hosts with optional inherited SSH defaults, targeting
-**v0.6.0**. v1 acceptance gates closed.
+**Current milestone:** Port forwarding — background SSH tunnels that outlive sshelf, targeting
+**v0.7.0**. (Sites shipped in v0.6.0.)
+
+---
+
+## 2026-06-21 — Port forwarding: background SSH tunnels (M0–M4)
+
+- New feature: **background port forwards** that survive sshelf exiting. `Ctrl-f` on a host opens
+  a popup (Local `-L` / Remote `-R` / Dynamic `-D` SOCKS); `F4` opens a manager that lists every
+  active forward and stops any.
+- Each forward is a detached `ssh -N` process in its own process group (std `process_group(0)`,
+  no new dep), tracked by PID in `forwards.json` and reconciled against the OS (`ps`) on launch,
+  on opening the manager, and each tick while it's open — with a zombie filter and a PID-reuse
+  guard. `ExitOnForwardFailure=yes` + a brief readiness poll surfaces bind/auth errors in the
+  popup. An M0 spike confirmed detached survival (PPID→1, own process group); an `#[ignore]` e2e
+  drives a real `-L` through a localhost sshd (bind → traffic → busy-port failure → kill).
+- New modules `forwards.rs`, `ui/forward_popup.rs`, `ui/forwards.rs`; the sshd e2e helper was
+  extracted into a shared `testsupport` module (transfer e2e now uses it too). Docs synced
+  (decisions D-021, data-model `forwards.json`, ux, structure, README, CHANGELOG). 168 tests +
+  2 e2e; clippy `-D warnings` + fmt clean. Targets **v0.7.0** via `feat/port-forward` → PR →
+  cut-release.
 
 ---
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -2,9 +2,10 @@
 
 > Keep this in sync with the actual tree (the docs-in-sync rule).
 >
-> **All modules present:** `main`, `app`, `askpass`, `config`, `import`, `model`, `paths`,
-> `search`, `secrets`, `ssh`, `state`, `store`, `transfer/{mod,worker,pane,screen}`, `vault`,
-> `ui/{mod,list,help,widgets,wizard,browse,settings,sites,transfer}`.
+> **All modules present:** `main`, `app`, `askpass`, `config`, `forwards`, `import`, `model`,
+> `paths`, `search`, `secrets`, `ssh`, `state`, `store`, `transfer/{mod,worker,pane,screen,e2e}`,
+> `testsupport` (test-only), `vault`,
+> `ui/{mod,list,help,widgets,wizard,browse,settings,sites,transfer,forward_popup,forwards}`.
 > (`error.rs` was removed — the codebase uses `anyhow` throughout.)
 
 ## Repository
@@ -30,6 +31,7 @@ ssh-tui/                 (crate/binary name: `sshelf`)
 | `model.rs` | `Host` + `Site` structs (+ `AuthMethod`); `Host::with_site_defaults`/`find_site` (site inheritance); serde derives. |
 | `store.rs` | Load/save `hosts.toml` with atomic write (temp + rename); load `config.toml`. |
 | `state.rs` | Frecency state (`use_count`, `last_used`) load/save (`state.json`); score computation. |
+| `forwards.rs` | Background port-forwards: the `ForwardSpec`/`ForwardEntry` model, the `-L/-R/-D` argv builder, spawn (detached `ssh -N` + readiness/error mapping), PID liveness/kill via `ps`/`kill`, reconcile, and `forwards.json` load/save. |
 | `secrets.rs` | `SecretStore` trait → keyring backend + `age`-vault fallback; `zeroize` on secrets. |
 | `ssh.rs` | Build `ssh` argv from a `Host`; terminal teardown + `exec()` handoff; askpass env wiring. |
 | `askpass.rs` | Headless askpass entry: inspect `argv[1]`; answer only password prompts via `secrets`. |
@@ -47,6 +49,8 @@ ssh-tui/                 (crate/binary name: `sshelf`)
 | `ui/browse.rs` | File-browser modal (fuzzy-filtered) for picking a key file anywhere on disk. |
 | `ui/settings.rs` | Settings screen (F2): config-file display + editable hosts-file location. |
 | `ui/sites.rs` | Sites manager (F3): list + add/edit/delete sites and their optional defaults; emits renames for the app to cascade. |
+| `ui/forward_popup.rs` | New-port-forward popup (Ctrl-f): kind chooser (Local/Remote/Dynamic) + ports/host fields + validation; emits a `ForwardSpec` for the app to spawn. |
+| `ui/forwards.rs` | Port-forwards manager (F4): lists all active forwards from a live snapshot; emits a kill request for the app to act on. |
 | `ui/help.rs` | Help overlay. |
 | `ui/widgets.rs` | Shared widgets: single-line text input (hand-rolled), keybind hint bar, confirm modal. |
 

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -47,10 +47,12 @@ list. Actions therefore use **Ctrl** (or function keys) to avoid being typed int
 | `Ctrl-d` | delete selected host (confirm) — M4 |
 | `Ctrl-y` | yank — copy/print the generated `ssh` command without connecting — M3 |
 | `Ctrl-t` | open the dual-pane **file-transfer** screen for the selected host |
+| `Ctrl-f` | open the **port-forward** popup for the selected host (runs in the background) |
 | `Ctrl-o` | import from `~/.ssh/config` (read-only) — M7 |
 | `F1` | help overlay |
 | `F2` | settings (config & hosts-file locations) |
 | `F3` | manage sites (create/edit/delete groups + their shared defaults) |
+| `F4` | manage **port forwards** (list all active, stop any) |
 | `Esc` | clear the query if non-empty, otherwise quit |
 | `Ctrl-c` | quit |
 
@@ -172,6 +174,31 @@ On failure the status line shows the underlying `sftp` error. For more detail, r
 `sshelf --transfer-log <FILE>` (or `$SSHELF_TRANSFER_LOG=<FILE>`): the worker appends every
 `ssh`/`sftp` command and its full stderr to that file. The log holds no secrets — the password
 reaches `ssh` via `SSH_ASKPASS`, never the command line.
+
+## Port forwarding (`Ctrl-f` / `F4`)
+
+`Ctrl-f` on a host opens a small popup to start an SSH port forward that **keeps running in the
+background even after you quit sshelf**. Pick a kind (cycle with ←/→):
+
+- **Local** (`-L`, the default) — open a local port that tunnels to a host reachable from the
+  server (e.g. expose a remote DB at `127.0.0.1:8080`).
+- **Remote** (`-R`) — open a port *on the server* that tunnels back to a host reachable from here.
+- **Dynamic** (`-D`) — a local SOCKS proxy that routes through the server.
+
+Fill in the ports/host (defaults: bind `127.0.0.1`, target host `localhost`) and `Ctrl-s` to
+start. sshelf spawns a detached `ssh -N …`, reusing the host's auth exactly as connect does
+(keys/agent/ProxyJump or the stored password via `SSH_ASKPASS`, plus any site defaults), and
+waits briefly to confirm it bound — a failure (port already in use, a privileged `<1024` port,
+the server refusing a remote bind, or an auth failure) is shown in the popup so you can fix a
+field and retry. On success the TUI returns to the list and the tunnel runs on its own.
+
+`F4` opens the **forwards manager**: every active forward across all hosts, with its host, an
+`L`/`R`/`D` summary (`L  127.0.0.1:8080 → db:3306`), pid and age. `d` (or `k`) → `y` stops the
+selected one. The list refreshes live, so a forward that ends — stopped here, `kill`ed from
+another terminal, or dropped on its own (sleep / network) — disappears within a moment. Forwards
+**survive sshelf exiting** (each is a detached process in its own process group) and the ledger
+(`forwards.json`) is reconciled against the running processes on every launch, so you only ever
+see forwards that are still actually running. See [`decisions.md`](decisions.md) D-021.
 
 ## CLI (outside the TUI)
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ use anyhow::Result;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use crate::config::Config;
+use crate::forwards::{self, ForwardsState};
 use crate::import;
 use crate::model::{CURRENT_FORMAT_VERSION, Host, HostsFile, Site};
 use crate::paths::Paths;
@@ -24,6 +25,8 @@ use crate::state::FrecencyState;
 use crate::store;
 use crate::transfer::{self, TransferOutcome};
 use crate::ui;
+use crate::ui::forward_popup::{ForwardPopup, ForwardPopupOutcome};
+use crate::ui::forwards::{ForwardsManager, ForwardsOutcome};
 use crate::ui::settings::{Settings, SettingsOutcome};
 use crate::ui::sites::{SitesManager, SitesOutcome};
 use crate::ui::wizard::{Wizard, WizardOutcome};
@@ -50,6 +53,9 @@ pub enum Outcome {
     Yank(usize),
     /// Open the transfer screen for this host (the loop spawns the worker after key handling).
     Transfer(usize),
+    /// Open the new-port-forward popup for this host (the loop opens it after key handling, so
+    /// resolving the host stays out of the testable `on_key`).
+    OpenForwardPopup(usize),
 }
 
 pub struct App {
@@ -73,6 +79,12 @@ pub struct App {
     pub settings: Option<Settings>,
     /// The sites manager (F3), when open.
     pub sites_manager: Option<SitesManager>,
+    /// The new-port-forward popup (Ctrl-f), when open.
+    pub forward_popup: Option<ForwardPopup>,
+    /// The port-forwards manager (F4), when open.
+    pub forwards_manager: Option<ForwardsManager>,
+    /// Active background port-forwards (the `forwards.json` ledger).
+    pub forwards_state: ForwardsState,
     /// The dual-pane file-transfer screen, when open.
     pub transfer: Option<transfer::TransferScreen>,
     /// Transient status line (cleared on next keypress).
@@ -106,6 +118,9 @@ impl App {
             confirm: None,
             settings: None,
             sites_manager: None,
+            forward_popup: None,
+            forwards_manager: None,
+            forwards_state: ForwardsState::default(),
             transfer: None,
             status: None,
             should_quit: false,
@@ -186,6 +201,14 @@ impl App {
             self.on_key_sites(key);
             return Outcome::Continue;
         }
+        if self.forward_popup.is_some() {
+            self.on_key_forward_popup(key);
+            return Outcome::Continue;
+        }
+        if self.forwards_manager.is_some() {
+            self.on_key_forwards(key);
+            return Outcome::Continue;
+        }
         match self.screen {
             Screen::Help => {
                 self.screen = Screen::List;
@@ -223,6 +246,10 @@ impl App {
                     return Outcome::Transfer(i);
                 }
             }
+            (KeyCode::Char('f'), true) => match self.current() {
+                Some(i) => return Outcome::OpenForwardPopup(i),
+                None => self.set_status("no host selected"),
+            },
             (KeyCode::Char('a'), true) => {
                 let names = self.site_names();
                 self.wizard = Some(Wizard::new_add(&names));
@@ -249,6 +276,7 @@ impl App {
             (KeyCode::F(1), _) => self.screen = Screen::Help,
             (KeyCode::F(2), _) => self.open_settings(),
             (KeyCode::F(3), _) => self.open_sites(),
+            (KeyCode::F(4), _) => self.open_forwards(),
             (KeyCode::Backspace, _) => {
                 self.query.pop();
                 self.selected = 0;
@@ -507,6 +535,99 @@ impl App {
         }
     }
 
+    /// Open the new-port-forward popup for `idx`. Called from the loop (mirrors `open_transfer`).
+    fn open_forward_popup(&mut self, idx: usize) {
+        self.forward_popup = Some(ForwardPopup::new(idx, self.hosts[idx].name.clone()));
+    }
+
+    fn on_key_forward_popup(&mut self, key: KeyEvent) {
+        let outcome = match self.forward_popup.as_mut() {
+            Some(p) => p.handle_key(key),
+            None => return,
+        };
+        match outcome {
+            ForwardPopupOutcome::Continue => {}
+            ForwardPopupOutcome::Cancel => self.forward_popup = None,
+            ForwardPopupOutcome::Create { kind, spec } => {
+                let Some(idx) = self.forward_popup.as_ref().map(ForwardPopup::host_idx) else {
+                    return;
+                };
+                // Resolve site defaults (bastion/user/port/identity) before building the ssh
+                // command; secrets/frecency still key on the original `host.id`.
+                let host = self.hosts[idx].with_site_defaults(&self.sites);
+                let has_secret = secrets::get_password(&self.paths.vault_file(), &host.id)
+                    .ok()
+                    .flatten()
+                    .is_some();
+                // Spawning blocks briefly (~2.5s) to catch a bind/auth failure; see forwards.rs.
+                match forwards::spawn_forward(&host, &self.hosts[idx].name, has_secret, kind, spec)
+                {
+                    Ok(entry) => {
+                        let display = entry.display.clone();
+                        self.forwards_state.forwards.push(entry);
+                        if let Err(e) = self.forwards_state.save(&self.paths.forwards_file()) {
+                            self.set_status(format!("forward up, but not saved: {e}"));
+                        } else {
+                            self.set_status(format!("forward up · {display}"));
+                        }
+                        self.forward_popup = None;
+                    }
+                    Err(e) => {
+                        if let Some(p) = self.forward_popup.as_mut() {
+                            p.set_error(e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Open the port-forwards manager (F4). Reconciles first so it opens showing only forwards
+    /// that are still actually running.
+    fn open_forwards(&mut self) {
+        self.reconcile_forwards();
+        self.forwards_manager = Some(ForwardsManager::new(self.forwards_state.forwards.clone()));
+    }
+
+    fn on_key_forwards(&mut self, key: KeyEvent) {
+        let outcome = match self.forwards_manager.as_mut() {
+            Some(m) => m.handle_key(key),
+            None => return,
+        };
+        match outcome {
+            ForwardsOutcome::Continue => {}
+            ForwardsOutcome::Close => self.forwards_manager = None,
+            ForwardsOutcome::Kill(id) => {
+                if let Some(entry) = self.forwards_state.forwards.iter().find(|e| e.id == id) {
+                    forwards::kill(entry);
+                }
+                self.forwards_state.forwards.retain(|e| e.id != id);
+                let _ = self.forwards_state.save(&self.paths.forwards_file());
+                self.refresh_forwards_manager();
+                self.set_status("forward stopped");
+            }
+        }
+    }
+
+    /// Drop ledger entries whose process has ended; persist if anything changed.
+    fn reconcile_forwards(&mut self) {
+        if !forwards::reconcile(&mut self.forwards_state).is_empty() {
+            let _ = self.forwards_state.save(&self.paths.forwards_file());
+        }
+    }
+
+    /// While the manager is open, reconcile and refresh its snapshot (called each tick, so a
+    /// forward that ends — externally or on its own — disappears within ~100ms without a keypress).
+    pub fn refresh_forwards_manager(&mut self) {
+        if self.forwards_manager.is_none() {
+            return;
+        }
+        self.reconcile_forwards();
+        if let Some(m) = self.forwards_manager.as_mut() {
+            m.set_forwards(self.forwards_state.forwards.clone());
+        }
+    }
+
     fn move_down(&mut self) {
         if !self.order.is_empty() && self.selected + 1 < self.order.len() {
             self.selected += 1;
@@ -560,6 +681,15 @@ fn run_with(start_add: bool) -> Result<()> {
     let file = store::load_hosts(&config.hosts_path(&paths))?;
     let state = FrecencyState::load(&paths.state_file())?;
     let mut app = App::new(file.hosts, file.sites, state, config, paths);
+    // Load the active-forward ledger and reconcile it against reality (drop any that ended while
+    // sshelf was closed), so the user sees only forwards that are still actually running.
+    match ForwardsState::load(&app.paths.forwards_file()) {
+        Ok(fs) => {
+            app.forwards_state = fs;
+            app.reconcile_forwards();
+        }
+        Err(e) => eprintln!("sshelf: warning: could not load forwards: {e:#}"),
+    }
     if start_add {
         let names = app.site_names();
         app.wizard = Some(Wizard::new_add(&names));
@@ -593,9 +723,9 @@ fn run_with(start_add: bool) -> Result<()> {
 fn event_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Result<()> {
     while !app.should_quit {
         terminal.draw(|frame| ui::render(frame, app))?;
-        if app.transfer.is_some() {
-            // The transfer screen is live: poll so worker events and progress animate without a
-            // keypress, then drain whatever the worker produced this tick.
+        // The transfer screen and the forwards manager are "live": poll so worker events /
+        // progress animate and a forward that dies disappears, both without needing a keypress.
+        if app.transfer.is_some() || app.forwards_manager.is_some() {
             if event::poll(Duration::from_millis(100))?
                 && let Event::Key(key) = event::read()?
             {
@@ -604,6 +734,7 @@ fn event_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Result<
             if let Some(screen) = app.transfer.as_mut() {
                 screen.drain_events();
             }
+            app.refresh_forwards_manager();
         } else if let Event::Key(key) = event::read()? {
             dispatch(app, key);
         }
@@ -628,6 +759,7 @@ fn dispatch(app: &mut App, key: KeyEvent) {
             }
         }
         Outcome::Transfer(idx) => app.open_transfer(idx),
+        Outcome::OpenForwardPopup(idx) => app.open_forward_popup(idx),
         Outcome::Continue => {}
     }
 }
@@ -765,6 +897,70 @@ mod tests {
         assert_eq!(
             app.on_key(ctrl(KeyCode::Char('t'))),
             Outcome::Transfer(expected)
+        );
+    }
+
+    #[test]
+    fn ctrl_f_opens_forward_popup_for_selected() {
+        let mut app = test_app();
+        let expected = app.order[app.selected];
+        assert_eq!(
+            app.on_key(ctrl(KeyCode::Char('f'))),
+            Outcome::OpenForwardPopup(expected)
+        );
+    }
+
+    #[test]
+    fn forward_popup_captures_keys() {
+        let mut app = test_app();
+        app.open_forward_popup(0);
+        assert!(app.forward_popup.is_some());
+        // typing now goes to the popup, not the query
+        app.on_key(key(KeyCode::Char('z')));
+        assert!(app.query.is_empty());
+        assert!(app.forward_popup.is_some());
+        // esc closes it
+        app.on_key(key(KeyCode::Esc));
+        assert!(app.forward_popup.is_none());
+    }
+
+    #[test]
+    fn f4_opens_forwards_manager() {
+        let mut app = test_app();
+        app.on_key(key(KeyCode::F(4)));
+        assert!(app.forwards_manager.is_some());
+        // typing routes to the manager, not the query
+        app.on_key(key(KeyCode::Char('z')));
+        assert!(app.query.is_empty());
+        app.on_key(key(KeyCode::Esc));
+        assert!(app.forwards_manager.is_none());
+    }
+
+    #[test]
+    fn opening_the_manager_reconciles_dead_forwards() {
+        use crate::forwards::{ForwardEntry, ForwardKind, ForwardSpec};
+        let mut app = test_app();
+        // A ledger entry pointing at a pid that is not our forward (here, pid 1 = launchd):
+        // reconcile must drop it when the manager opens.
+        app.forwards_state.forwards.push(ForwardEntry {
+            id: "bogus".into(),
+            host_id: "h".into(),
+            host_name: "web".into(),
+            kind: ForwardKind::Local,
+            spec: ForwardSpec {
+                bind: None,
+                listen_port: 8080,
+                target_host: Some("db".into()),
+                target_port: Some(3306),
+            },
+            display: "L  127.0.0.1:8080 → db:3306".into(),
+            pid: 1,
+            started_at: 0,
+        });
+        app.on_key(key(KeyCode::F(4)));
+        assert!(
+            app.forwards_state.forwards.is_empty(),
+            "dead forward should be reconciled away"
         );
     }
 

--- a/src/forwards.rs
+++ b/src/forwards.rs
@@ -1,0 +1,705 @@
+//! Background SSH port-forwards that outlive sshelf.
+//!
+//! A forward is a single detached `ssh -N -L|-R|-D …` process. We reuse the connect/transfer
+//! machinery ([`ssh::build_args`] + [`ssh::configure_askpass`]) so keys, agents, ProxyJump and
+//! stored passwords all work exactly as a normal connect — then detach the child into its **own
+//! process group** ([`std::os::unix::process::CommandExt::process_group`]) with null stdin/stdout
+//! so it survives both sshelf exiting (orphaned → reparented to init) and the terminal closing
+//! (its own process group never receives the shell's hangup). Nothing here kills a forward on
+//! drop or on app shutdown — that is what keeps it running.
+//!
+//! There is no daemon: the running `ssh` processes are the source of truth and [`ForwardsState`]
+//! (`forwards.json`) is just a remembered list of PIDs. [`reconcile`] re-validates every PID
+//! against the OS (via `ps`), so a forward that ends — stopped here, `kill`ed elsewhere, or
+//! dropped on its own — leaves the ledger; only forwards that are *still actually running*
+//! persist (across sshelf's own exit and relaunch).
+
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::model::Host;
+use crate::ssh;
+use crate::state::now_unix;
+use crate::store::atomic_write;
+
+/// Poll cadence while waiting for a freshly-spawned forward to come up or fail.
+const POLL: Duration = Duration::from_millis(100);
+/// How long to wait for `ssh` to authenticate + bind before treating a still-running child as
+/// "up". A bind/auth failure makes `ssh` (with `ExitOnForwardFailure=yes`) exit well within this;
+/// a child still alive at the deadline is taken as up (and `reconcile` self-heals a late death).
+const READINESS_GRACE: Duration = Duration::from_millis(2500);
+/// After `SIGTERM`, wait at most this long for the forward to die before escalating to `SIGKILL`.
+const KILL_GRACE: Duration = Duration::from_millis(600);
+
+/// Which direction a forward tunnels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ForwardKind {
+    /// `-L` — bind a local port that tunnels to a host reachable from the server.
+    Local,
+    /// `-R` — bind a port on the server that tunnels back to a host reachable from us.
+    Remote,
+    /// `-D` — bind a local SOCKS proxy that routes through the server.
+    Dynamic,
+}
+
+impl ForwardKind {
+    /// Every kind, in the order the popup chooser cycles them (Local is the default).
+    pub const ALL: [ForwardKind; 3] = [
+        ForwardKind::Local,
+        ForwardKind::Remote,
+        ForwardKind::Dynamic,
+    ];
+
+    /// The `ssh` flag that selects this kind.
+    pub fn flag(self) -> &'static str {
+        match self {
+            ForwardKind::Local => "-L",
+            ForwardKind::Remote => "-R",
+            ForwardKind::Dynamic => "-D",
+        }
+    }
+
+    /// Human label for the chooser.
+    pub fn label(self) -> &'static str {
+        match self {
+            ForwardKind::Local => "Local",
+            ForwardKind::Remote => "Remote",
+            ForwardKind::Dynamic => "Dynamic",
+        }
+    }
+
+    /// Single-letter tag used in the manager's display string.
+    fn tag(self) -> char {
+        match self {
+            ForwardKind::Local => 'L',
+            ForwardKind::Remote => 'R',
+            ForwardKind::Dynamic => 'D',
+        }
+    }
+}
+
+/// The ports/hosts of one forward. Field roles depend on the kind:
+/// - **Local** (`-L`): `listen_port` is the local port; `target_host`:`target_port` is the
+///   destination reached *from the server*.
+/// - **Remote** (`-R`): `listen_port` is the port bound *on the server*; `target_host`:`target_port`
+///   is the destination reached *from us*.
+/// - **Dynamic** (`-D`): only `listen_port` (the local SOCKS port); the target fields are unused.
+///
+/// `bind` is the listen interface, defaulting to loopback (`127.0.0.1`); `target_host` defaults to
+/// `localhost`. These defaults are applied in [`ForwardSpec::spec_string`], not stored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForwardSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bind: Option<String>,
+    pub listen_port: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_port: Option<u16>,
+}
+
+impl ForwardSpec {
+    fn bind_or_default(&self) -> &str {
+        self.bind
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("127.0.0.1")
+    }
+
+    fn target_or_default(&self) -> &str {
+        self.target_host
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("localhost")
+    }
+
+    /// The value passed after the `-L`/`-R`/`-D` flag, with defaults applied.
+    pub fn spec_string(&self, kind: ForwardKind) -> String {
+        let bind = self.bind_or_default();
+        match kind {
+            ForwardKind::Dynamic => format!("{bind}:{}", self.listen_port),
+            ForwardKind::Local | ForwardKind::Remote => format!(
+                "{bind}:{}:{}:{}",
+                self.listen_port,
+                self.target_or_default(),
+                self.target_port.unwrap_or(0),
+            ),
+        }
+    }
+
+    /// A compact human description for the forwards manager (e.g. `L  127.0.0.1:8080 → db:3306`).
+    pub fn display_string(&self, kind: ForwardKind) -> String {
+        let bind = self.bind_or_default();
+        match kind {
+            ForwardKind::Dynamic => format!("{}  {bind}:{} (SOCKS)", kind.tag(), self.listen_port),
+            ForwardKind::Local | ForwardKind::Remote => format!(
+                "{}  {bind}:{} → {}:{}",
+                kind.tag(),
+                self.listen_port,
+                self.target_or_default(),
+                self.target_port.unwrap_or(0),
+            ),
+        }
+    }
+
+    /// Validate the user-entered ports. Privileged ports (<1024) are *not* rejected here — they
+    /// surface as a friendly bind error from `ssh` if the OS refuses them.
+    pub fn validate(&self, kind: ForwardKind) -> Result<(), String> {
+        if self.listen_port == 0 {
+            return Err("listen port must be between 1 and 65535".into());
+        }
+        if matches!(kind, ForwardKind::Local | ForwardKind::Remote)
+            && !matches!(self.target_port, Some(p) if p != 0)
+        {
+            return Err("destination port must be between 1 and 65535".into());
+        }
+        Ok(())
+    }
+}
+
+/// One active forward, as recorded in `forwards.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForwardEntry {
+    /// Stable id (ULID); also names the forward's stderr log file.
+    pub id: String,
+    /// The originating [`Host::id`] (so secrets/site could be re-resolved later).
+    pub host_id: String,
+    /// The host's display name, snapshotted (the host may be renamed/deleted afterwards).
+    pub host_name: String,
+    pub kind: ForwardKind,
+    pub spec: ForwardSpec,
+    /// Precomputed display string for the manager.
+    pub display: String,
+    pub pid: i32,
+    pub started_at: i64,
+}
+
+impl ForwardEntry {
+    /// The token that must appear in the live process's command line for it to be *our* forward
+    /// (guards against PID reuse).
+    fn spec_token(&self) -> String {
+        self.spec.spec_string(self.kind)
+    }
+}
+
+/// The whole `forwards.json`: a flat list of active forwards.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ForwardsState {
+    pub forwards: Vec<ForwardEntry>,
+}
+
+impl ForwardsState {
+    /// Load state; a missing/empty file yields default (empty) state.
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let text =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        if text.trim().is_empty() {
+            return Ok(Self::default());
+        }
+        serde_json::from_str(&text).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let text = serde_json::to_string_pretty(self).context("serializing forwards")?;
+        atomic_write(path, text.as_bytes(), 0o600)
+    }
+}
+
+/// The `-L|-R|-D <spec>` arguments for one forward (no IO; unit-tested).
+pub fn forward_args(kind: ForwardKind, spec: &ForwardSpec) -> Vec<String> {
+    vec![kind.flag().to_string(), spec.spec_string(kind)]
+}
+
+/// The full argv (excluding the program name) for a forward: the constant `-N
+/// -o ExitOnForwardFailure=yes`, the forward spec, then the host's normal `ssh` args.
+pub fn build_forward_command(host: &Host, kind: ForwardKind, spec: &ForwardSpec) -> Vec<String> {
+    let mut a = vec![
+        "-N".to_string(),
+        "-o".to_string(),
+        "ExitOnForwardFailure=yes".to_string(),
+    ];
+    a.extend(forward_args(kind, spec));
+    a.extend(ssh::build_args(host, true));
+    a
+}
+
+/// Where a forward's stderr is logged (a regular file, so a long-lived `ssh` never gets SIGPIPE
+/// from a closed pipe). Derived from the id, so `reconcile`/`kill` can clean it up too.
+fn log_path_for(id: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("sshelf-fwd-{id}.log"))
+}
+
+/// Spawn a detached forward for `host` (already resolved with site defaults) and wait briefly to
+/// catch an immediate bind/auth failure. On success returns the [`ForwardEntry`] to record; on
+/// failure returns a friendly message (the popup keeps it open so the user can fix a field).
+pub fn spawn_forward(
+    host: &Host,
+    host_name: &str,
+    has_secret: bool,
+    kind: ForwardKind,
+    spec: ForwardSpec,
+) -> Result<ForwardEntry, String> {
+    spec.validate(kind)?;
+
+    let id = ulid::Ulid::new().to_string();
+    let log_path = log_path_for(&id);
+    let errfile = std::fs::File::create(&log_path)
+        .map_err(|e| format!("could not create forward log {}: {e}", log_path.display()))?;
+
+    let mut cmd = Command::new("ssh");
+    cmd.args(build_forward_command(host, kind, &spec));
+    ssh::configure_askpass(&mut cmd, host, has_secret);
+    cmd.process_group(0) // own process group → survives terminal close
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(errfile));
+
+    let mut child = cmd.spawn().map_err(|e| {
+        let _ = std::fs::remove_file(&log_path);
+        format!("could not launch ssh: {e}")
+    })?;
+    let pid = child.id() as i32;
+
+    let deadline = Instant::now() + READINESS_GRACE;
+    loop {
+        match child.try_wait() {
+            // Exited before the grace elapsed → the bind or auth failed.
+            Ok(Some(status)) => {
+                let stderr = std::fs::read_to_string(&log_path).unwrap_or_default();
+                let _ = std::fs::remove_file(&log_path);
+                return Err(classify_forward_error(&stderr, kind, &spec, status.code()));
+            }
+            Ok(None) => {}
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = std::fs::remove_file(&log_path);
+                return Err(format!("ssh error: {e}"));
+            }
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(POLL);
+    }
+
+    // Still alive → up. Drop the Child WITHOUT waiting or killing it (Child::drop does neither on
+    // Unix), so the forward keeps running and is reparented to init when sshelf exits.
+    drop(child);
+    Ok(ForwardEntry {
+        id,
+        host_id: host.id.clone(),
+        host_name: host_name.to_string(),
+        kind,
+        display: spec.display_string(kind),
+        spec,
+        pid,
+        started_at: now_unix(),
+    })
+}
+
+/// Ask the OS for a pid's process state + command line. `None` if the pid is gone. Uses `-ww` so
+/// the command isn't width-truncated (Linux), and reads `state` first so a zombie is detectable.
+fn ps_state_command(pid: i32) -> Option<(String, String)> {
+    let out = Command::new("ps")
+        .args(["-ww", "-o", "state=,command=", "-p", &pid.to_string()])
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let line = stdout.trim();
+    if line.is_empty() {
+        return None;
+    }
+    match line.split_once(char::is_whitespace) {
+        Some((state, command)) => Some((state.trim().to_string(), command.trim().to_string())),
+        None => Some((line.to_string(), String::new())),
+    }
+}
+
+/// Decide, from a pid's `ps` state + command, whether it is still *our* live forward. A zombie
+/// (state `Z`) is dead; a command that no longer matches our `ssh … <spec>` means the pid was
+/// recycled (PID reuse) — also "not ours".
+fn parse_ps_alive(state: &str, command: &str, spec_token: &str) -> bool {
+    !state.starts_with('Z') && command.contains("ssh") && command.contains(spec_token)
+}
+
+/// Whether a recorded forward's process is still alive and still ours.
+fn is_alive(entry: &ForwardEntry) -> bool {
+    match ps_state_command(entry.pid) {
+        Some((state, command)) => parse_ps_alive(&state, &command, &entry.spec_token()),
+        None => false,
+    }
+}
+
+/// Stop a forward: `SIGTERM`, then `SIGKILL` if it lingers — but only signal the pid while it is
+/// verifiably still ours (so a recycled pid is never signalled). Also removes its stderr log.
+pub fn kill(entry: &ForwardEntry) {
+    if is_alive(entry) {
+        let _ = signal(entry.pid, "TERM");
+        let deadline = Instant::now() + KILL_GRACE;
+        while Instant::now() < deadline {
+            if !is_alive(entry) {
+                break;
+            }
+            std::thread::sleep(POLL);
+        }
+        if is_alive(entry) {
+            let _ = signal(entry.pid, "KILL");
+        }
+    }
+    let _ = std::fs::remove_file(log_path_for(&entry.id));
+}
+
+fn signal(pid: i32, sig: &str) -> std::io::Result<()> {
+    Command::new("kill")
+        .args([&format!("-{sig}"), &pid.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|_| ())
+}
+
+/// Drop every recorded forward whose process is gone (dead, zombie, or a recycled pid), returning
+/// the dropped entries (for a status line). Cleans up the stderr log of each removed forward.
+pub fn reconcile(state: &mut ForwardsState) -> Vec<ForwardEntry> {
+    let mut dropped = Vec::new();
+    state.forwards.retain(|e| {
+        if is_alive(e) {
+            true
+        } else {
+            let _ = std::fs::remove_file(log_path_for(&e.id));
+            dropped.push(e.clone());
+            false
+        }
+    });
+    dropped
+}
+
+/// Map a forward's failure (its full stderr + exit code) to a friendly, actionable message. The
+/// whole stderr is scanned because the useful line ("Address already in use") is often not the
+/// last one — ssh appends a generic "Could not request local forwarding." after it.
+fn classify_forward_error(
+    stderr: &str,
+    kind: ForwardKind,
+    spec: &ForwardSpec,
+    code: Option<i32>,
+) -> String {
+    let low = stderr.to_lowercase();
+    let port = spec.listen_port;
+    let where_ = match kind {
+        ForwardKind::Remote => "remote",
+        _ => "local",
+    };
+
+    if low.contains("address already in use") || low.contains("cannot listen to port") {
+        return format!("the {where_} port {port} is already in use — pick another");
+    }
+    if low.contains("privileged ports")
+        || (low.contains("permission denied") && low.contains("bind"))
+    {
+        return format!(
+            "port {port} is privileged (below 1024) — use a port ≥ 1024 or run as root"
+        );
+    }
+    if low.contains("remote port forwarding failed") {
+        return "the server refused the remote forward (check its sshd GatewayPorts setting)"
+            .into();
+    }
+    if low.contains("could not resolve")
+        || low.contains("name or service not known")
+        || low.contains("nodename nor servname")
+    {
+        return "could not resolve the host".into();
+    }
+    if low.contains("connection refused") {
+        return "connection refused".into();
+    }
+    if low.contains("timed out") || low.contains("timeout") {
+        return "connection timed out".into();
+    }
+    if low.contains("permission denied")
+        || low.contains("authentication failed")
+        || low.contains("too many authentication failures")
+    {
+        return "authentication failed".into();
+    }
+    // Unknown failure: show the most useful (last non-blank) line, else the exit code.
+    if let Some(line) = tidy_error(stderr) {
+        return line;
+    }
+    match code {
+        Some(c) => format!("ssh exited (code {c}) before the forward came up"),
+        None => "ssh exited before the forward came up".into(),
+    }
+}
+
+/// The last non-blank line of `raw` (ssh puts the real cause last), if any.
+fn tidy_error(raw: &str) -> Option<String> {
+    raw.lines()
+        .rev()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn local(listen: u16, host: &str, target: u16) -> ForwardSpec {
+        ForwardSpec {
+            bind: None,
+            listen_port: listen,
+            target_host: Some(host.into()),
+            target_port: Some(target),
+        }
+    }
+
+    #[test]
+    fn local_args_apply_bind_and_host_defaults() {
+        let s = local(8080, "db", 3306);
+        assert_eq!(
+            forward_args(ForwardKind::Local, &s),
+            vec!["-L", "127.0.0.1:8080:db:3306"]
+        );
+    }
+
+    #[test]
+    fn explicit_bind_and_empty_host_default() {
+        let s = ForwardSpec {
+            bind: Some("0.0.0.0".into()),
+            listen_port: 9090,
+            target_host: None, // → localhost
+            target_port: Some(3000),
+        };
+        assert_eq!(
+            forward_args(ForwardKind::Remote, &s),
+            vec!["-R", "0.0.0.0:9090:localhost:3000"]
+        );
+    }
+
+    #[test]
+    fn dynamic_args_are_bind_and_port_only() {
+        let s = ForwardSpec {
+            bind: None,
+            listen_port: 1080,
+            target_host: None,
+            target_port: None,
+        };
+        assert_eq!(
+            forward_args(ForwardKind::Dynamic, &s),
+            vec!["-D", "127.0.0.1:1080"]
+        );
+    }
+
+    #[test]
+    fn build_command_prepends_exit_on_forward_failure() {
+        let mut h = Host::new("web", "10.0.0.1");
+        h.user = Some("deploy".into());
+        let argv = build_forward_command(&h, ForwardKind::Local, &local(8080, "db", 3306));
+        assert_eq!(argv[0], "-N");
+        assert_eq!(&argv[1..3], &["-o", "ExitOnForwardFailure=yes"]);
+        assert!(
+            argv.windows(2)
+                .any(|w| w == ["-L", "127.0.0.1:8080:db:3306"])
+        );
+        assert_eq!(argv.last().unwrap(), "deploy@10.0.0.1");
+    }
+
+    #[test]
+    fn display_strings_read_well() {
+        assert_eq!(
+            local(8080, "db", 3306).display_string(ForwardKind::Local),
+            "L  127.0.0.1:8080 → db:3306"
+        );
+        let dyn_spec = ForwardSpec {
+            bind: None,
+            listen_port: 1080,
+            target_host: None,
+            target_port: None,
+        };
+        assert_eq!(
+            dyn_spec.display_string(ForwardKind::Dynamic),
+            "D  127.0.0.1:1080 (SOCKS)"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_zero_ports_and_missing_target() {
+        assert!(local(0, "db", 3306).validate(ForwardKind::Local).is_err());
+        assert!(local(8080, "db", 0).validate(ForwardKind::Local).is_err());
+        let no_target = ForwardSpec {
+            bind: None,
+            listen_port: 8080,
+            target_host: None,
+            target_port: None,
+        };
+        assert!(no_target.validate(ForwardKind::Local).is_err());
+        // Dynamic needs only the listen port.
+        assert!(no_target.validate(ForwardKind::Dynamic).is_ok());
+    }
+
+    #[test]
+    fn classify_maps_known_stderr() {
+        let s = local(8080, "db", 3306);
+        // The real multi-line stderr: the useful line is NOT last (ssh appends a generic line).
+        let busy = "bind [127.0.0.1]:8080: Address already in use\n\
+                    channel_setup_fwd_listener_tcpip: cannot listen to port: 8080\n\
+                    Could not request local forwarding.";
+        assert!(
+            classify_forward_error(busy, ForwardKind::Local, &s, Some(255))
+                .contains("already in use")
+        );
+        let privileged =
+            "bind [127.0.0.1]:80: Permission denied\nCould not request local forwarding.";
+        assert!(
+            classify_forward_error(privileged, ForwardKind::Local, &s, Some(255))
+                .contains("privileged")
+        );
+        assert!(
+            classify_forward_error(
+                "Warning: remote port forwarding failed for listen port 80",
+                ForwardKind::Remote,
+                &s,
+                Some(255),
+            )
+            .contains("server refused")
+        );
+        assert!(
+            classify_forward_error(
+                "ssh: Could not resolve hostname nope",
+                ForwardKind::Local,
+                &s,
+                Some(255)
+            )
+            .contains("resolve")
+        );
+        assert!(
+            classify_forward_error(
+                "Permission denied (publickey,password).",
+                ForwardKind::Local,
+                &s,
+                Some(255)
+            )
+            .contains("authentication")
+        );
+        // Unknown line falls back to the line itself; empty falls back to the exit code.
+        assert_eq!(
+            classify_forward_error("weird ssh message", ForwardKind::Local, &s, Some(7)),
+            "weird ssh message"
+        );
+        assert!(classify_forward_error("", ForwardKind::Local, &s, Some(7)).contains("code 7"));
+    }
+
+    #[test]
+    fn ps_alive_filters_zombie_and_pid_reuse() {
+        let token = "127.0.0.1:8080:db:3306";
+        let cmd = format!("/usr/bin/ssh -N -o ExitOnForwardFailure=yes -L {token} deploy@10.0.0.1");
+        // Live, ours.
+        assert!(parse_ps_alive("S", &cmd, token));
+        assert!(parse_ps_alive("Ss", &cmd, token));
+        // Zombie → dead even though the command still matches.
+        assert!(!parse_ps_alive("Z", &cmd, token));
+        // PID reused by something else → not ours.
+        assert!(!parse_ps_alive("S", "/usr/bin/vim notes.txt", token));
+        // A different forward's command (different spec) → not ours.
+        assert!(!parse_ps_alive(
+            "S",
+            "/usr/bin/ssh -N -L 127.0.0.1:9999:x:1 a@b",
+            token
+        ));
+    }
+
+    #[test]
+    fn forwards_state_round_trips_and_missing_is_default() {
+        let dir = std::env::temp_dir().join(format!("sshelf-fwd-test-{}", ulid::Ulid::new()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("forwards.json");
+        assert!(ForwardsState::load(&path).unwrap().forwards.is_empty());
+
+        let state = ForwardsState {
+            forwards: vec![ForwardEntry {
+                id: "01ABC".into(),
+                host_id: "01HOST".into(),
+                host_name: "web".into(),
+                kind: ForwardKind::Local,
+                spec: local(8080, "db", 3306),
+                display: "L  127.0.0.1:8080 → db:3306".into(),
+                pid: 4242,
+                started_at: 1_700_000_000,
+            }],
+        };
+        state.save(&path).unwrap();
+        let loaded = ForwardsState::load(&path).unwrap();
+        assert_eq!(loaded.forwards, state.forwards);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    #[ignore = "spawns a real sshd + ssh; run with `cargo test -- --ignored`"]
+    fn forward_binds_tunnels_and_kills() {
+        use std::io::Read;
+        use std::net::{TcpListener, TcpStream};
+
+        let Some(sshd) = crate::testsupport::start_sshd() else {
+            eprintln!("skipping e2e: no usable sshd on this host");
+            return;
+        };
+        let host = crate::testsupport::host_for(&sshd);
+
+        // Grab a free local port (bind to 0, read it, release it) to listen on.
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let local_port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        // Local forward: local_port → 127.0.0.1:<sshd port> (reachable from the server == us).
+        let spec = ForwardSpec {
+            bind: None,
+            listen_port: local_port,
+            target_host: Some("127.0.0.1".into()),
+            target_port: Some(sshd.port),
+        };
+        let entry = spawn_forward(&host, "e2e", false, ForwardKind::Local, spec.clone())
+            .expect("forward should come up");
+        assert!(
+            is_alive(&entry),
+            "forward should be alive right after spawn"
+        );
+
+        // Traffic flows: connecting the local port reaches the forwarded sshd banner.
+        let mut stream = TcpStream::connect(("127.0.0.1", local_port)).expect("connect to forward");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut buf = [0u8; 4];
+        stream.read_exact(&mut buf).expect("read forwarded banner");
+        assert_eq!(&buf, b"SSH-", "expected the forwarded SSH banner");
+        drop(stream);
+
+        // ExitOnForwardFailure: a second forward on the same port fails with a clear message.
+        let err = spawn_forward(&host, "e2e", false, ForwardKind::Local, spec)
+            .expect_err("second bind on the same port must fail");
+        assert!(err.contains("already in use"), "unexpected error: {err}");
+
+        // Kill the first forward; it dies and reconcile then drops it from a ledger.
+        kill(&entry);
+        assert!(!is_alive(&entry), "forward should be gone after kill");
+        let mut state = ForwardsState {
+            forwards: vec![entry.clone()],
+        };
+        assert_eq!(reconcile(&mut state).len(), 1);
+        assert!(state.forwards.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 mod app;
 mod askpass;
 mod config;
+mod forwards;
 mod import;
 mod model;
 mod paths;
@@ -16,6 +17,8 @@ mod secrets;
 mod ssh;
 mod state;
 mod store;
+#[cfg(test)]
+mod testsupport;
 mod transfer;
 mod ui;
 mod vault;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -62,6 +62,11 @@ impl Paths {
         self.data_dir.join("state.json")
     }
 
+    /// App-owned ledger of active background port-forwards.
+    pub fn forwards_file(&self) -> PathBuf {
+        self.data_dir.join("forwards.json")
+    }
+
     /// Encrypted secret vault (fallback when no OS keyring is available).
     #[allow(dead_code)] // used by the vault backend (M5)
     pub fn vault_file(&self) -> PathBuf {

--- a/src/testsupport.rs
+++ b/src/testsupport.rs
@@ -1,0 +1,128 @@
+//! Shared test scaffolding: a throwaway, rootless `sshd` on localhost for the `#[ignore]`d e2e
+//! tests (transfer + port-forward). Spawning a real `sshd` + `ssh`/`sftp` means these tests only
+//! run with `cargo test -- --ignored` on a machine with OpenSSH installed.
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::time::{Duration, Instant};
+
+use crate::model::{AuthMethod, Host};
+
+static NEXT_PORT: AtomicU16 = AtomicU16::new(47137);
+
+/// A running throwaway `sshd`; killed and cleaned up on drop.
+pub(crate) struct Sshd {
+    child: Child,
+    pub(crate) dir: PathBuf,
+    pub(crate) port: u16,
+    key: PathBuf,
+    known_hosts: PathBuf,
+}
+
+impl Drop for Sshd {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn sftp_server() -> Option<&'static str> {
+    [
+        "/usr/libexec/sftp-server",     // macOS
+        "/usr/lib/openssh/sftp-server", // Debian/Ubuntu
+        "/usr/lib/ssh/sftp-server",     // Arch
+    ]
+    .into_iter()
+    .find(|p| Path::new(p).exists())
+}
+
+fn keygen(path: &Path) {
+    let ok = Command::new("ssh-keygen")
+        .args(["-q", "-t", "ed25519", "-N", ""])
+        .arg("-f")
+        .arg(path)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    assert!(ok, "ssh-keygen failed");
+}
+
+/// Start a key-auth `sshd` on a free localhost port, or `None` if the host lacks the binaries.
+pub(crate) fn start_sshd() -> Option<Sshd> {
+    let sftp = sftp_server()?;
+    if !Path::new("/usr/sbin/sshd").exists() {
+        return None;
+    }
+    let dir = std::env::temp_dir().join(format!("sshelf-e2e-{}", ulid::Ulid::new()));
+    std::fs::create_dir_all(&dir).ok()?;
+    let hostkey = dir.join("hostkey");
+    let key = dir.join("id");
+    keygen(&hostkey);
+    keygen(&key);
+    let authorized = dir.join("authorized_keys");
+    std::fs::copy(dir.join("id.pub"), &authorized).ok()?;
+
+    let port = NEXT_PORT.fetch_add(1, Ordering::Relaxed);
+    let cfg = dir.join("sshd_config");
+    std::fs::write(
+        &cfg,
+        format!(
+            "Port {port}\n\
+             ListenAddress 127.0.0.1\n\
+             HostKey {hostkey}\n\
+             PidFile {pid}\n\
+             AuthorizedKeysFile {authorized}\n\
+             PasswordAuthentication no\n\
+             UsePAM no\n\
+             StrictModes no\n\
+             Subsystem sftp {sftp}\n",
+            hostkey = hostkey.display(),
+            pid = dir.join("pid").display(),
+            authorized = authorized.display(),
+        ),
+    )
+    .ok()?;
+
+    let child = Command::new("/usr/sbin/sshd")
+        .arg("-f")
+        .arg(&cfg)
+        .args(["-D", "-e"])
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let sshd = Sshd {
+        child,
+        dir: dir.clone(),
+        port,
+        key,
+        known_hosts: dir.join("known_hosts"),
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return Some(sshd);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    None // `sshd` dropped here → killed + cleaned up
+}
+
+/// A `Host` pointing at the throwaway server (key auth; test-only ssh options via `extra_args`).
+pub(crate) fn host_for(sshd: &Sshd) -> Host {
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "root".into());
+    let mut h = Host::new("e2e", "127.0.0.1");
+    h.user = Some(user);
+    h.port = Some(sshd.port);
+    h.auth = AuthMethod::Key;
+    h.identity_files = vec![sshd.key.to_string_lossy().into_owned()];
+    h.extra_args = Some(format!(
+        "-o UserKnownHostsFile={} -o IdentitiesOnly=yes",
+        sshd.known_hosts.display()
+    ));
+    h
+}

--- a/src/transfer/e2e.rs
+++ b/src/transfer/e2e.rs
@@ -7,134 +7,14 @@
 //! transport works against a real server. The unit tests cover the pure pieces (argv builders,
 //! `ls -l` parsing, progress math); this is the integration layer the M0 spike proved by hand.
 
-use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::path::Path;
 use std::sync::mpsc::Receiver;
 use std::time::{Duration, Instant};
 
-use crate::model::{AuthMethod, Host};
+use crate::testsupport::{host_for, start_sshd};
 
 use super::worker::TransferSession;
 use super::{Direction, TransferJob, WorkerCmd, WorkerEvent};
-
-static NEXT_PORT: AtomicU16 = AtomicU16::new(47137);
-
-/// A running throwaway `sshd`; killed and cleaned up on drop.
-struct Sshd {
-    child: Child,
-    dir: PathBuf,
-    port: u16,
-    key: PathBuf,
-    known_hosts: PathBuf,
-}
-
-impl Drop for Sshd {
-    fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-        let _ = std::fs::remove_dir_all(&self.dir);
-    }
-}
-
-fn sftp_server() -> Option<&'static str> {
-    [
-        "/usr/libexec/sftp-server",     // macOS
-        "/usr/lib/openssh/sftp-server", // Debian/Ubuntu
-        "/usr/lib/ssh/sftp-server",     // Arch
-    ]
-    .into_iter()
-    .find(|p| Path::new(p).exists())
-}
-
-fn keygen(path: &Path) {
-    let ok = Command::new("ssh-keygen")
-        .args(["-q", "-t", "ed25519", "-N", ""])
-        .arg("-f")
-        .arg(path)
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-    assert!(ok, "ssh-keygen failed");
-}
-
-/// Start a key-auth `sshd` on a free localhost port, or `None` if the host lacks the binaries.
-fn start_sshd() -> Option<Sshd> {
-    let sftp = sftp_server()?;
-    if !Path::new("/usr/sbin/sshd").exists() {
-        return None;
-    }
-    let dir = std::env::temp_dir().join(format!("sshelf-e2e-{}", ulid::Ulid::new()));
-    std::fs::create_dir_all(&dir).ok()?;
-    let hostkey = dir.join("hostkey");
-    let key = dir.join("id");
-    keygen(&hostkey);
-    keygen(&key);
-    let authorized = dir.join("authorized_keys");
-    std::fs::copy(dir.join("id.pub"), &authorized).ok()?;
-
-    let port = NEXT_PORT.fetch_add(1, Ordering::Relaxed);
-    let cfg = dir.join("sshd_config");
-    std::fs::write(
-        &cfg,
-        format!(
-            "Port {port}\n\
-             ListenAddress 127.0.0.1\n\
-             HostKey {hostkey}\n\
-             PidFile {pid}\n\
-             AuthorizedKeysFile {authorized}\n\
-             PasswordAuthentication no\n\
-             UsePAM no\n\
-             StrictModes no\n\
-             Subsystem sftp {sftp}\n",
-            hostkey = hostkey.display(),
-            pid = dir.join("pid").display(),
-            authorized = authorized.display(),
-        ),
-    )
-    .ok()?;
-
-    let child = Command::new("/usr/sbin/sshd")
-        .arg("-f")
-        .arg(&cfg)
-        .args(["-D", "-e"])
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
-    let sshd = Sshd {
-        child,
-        dir: dir.clone(),
-        port,
-        key,
-        known_hosts: dir.join("known_hosts"),
-    };
-
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while Instant::now() < deadline {
-        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            return Some(sshd);
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-    None // `sshd` dropped here → killed + cleaned up
-}
-
-/// A `Host` pointing at the throwaway server (key auth; test-only ssh options via `extra_args`).
-fn host_for(sshd: &Sshd) -> Host {
-    let user = std::env::var("USER")
-        .or_else(|_| std::env::var("LOGNAME"))
-        .unwrap_or_else(|_| "root".into());
-    let mut h = Host::new("e2e", "127.0.0.1");
-    h.user = Some(user);
-    h.port = Some(sshd.port);
-    h.auth = AuthMethod::Key;
-    h.identity_files = vec![sshd.key.to_string_lossy().into_owned()];
-    h.extra_args = Some(format!(
-        "-o UserKnownHostsFile={} -o IdentitiesOnly=yes",
-        sshd.known_hosts.display()
-    ));
-    h
-}
 
 /// Block (up to 15s) for the next event matching `pred`, returning it.
 fn recv_until(rx: &Receiver<WorkerEvent>, pred: impl Fn(&WorkerEvent) -> bool) -> WorkerEvent {

--- a/src/ui/forward_popup.rs
+++ b/src/ui/forward_popup.rs
@@ -1,0 +1,444 @@
+//! The "new port forward" popup (a self-contained component: state + key handling + render).
+//!
+//! A small form opened with `Ctrl-f` on the selected host. The user picks a kind (Local /
+//! Remote / Dynamic — cycled with ←/→) and fills in the ports/host; the active fields depend on
+//! the kind. `Ctrl-s` (or Enter on the last field) confirms, returning the [`ForwardSpec`] for the
+//! app to spawn; a validation or bind/auth error keeps the popup open with the message.
+
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use super::centered;
+use super::widgets::TextField;
+use crate::forwards::{ForwardKind, ForwardSpec};
+
+/// Columns before a field's value: marker(2) + padded label(12) + space(1).
+const VALUE_COL: u16 = 15;
+const LABEL_W: usize = 12;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Field {
+    Kind,
+    Bind,
+    ListenPort,
+    TargetHost,
+    TargetPort,
+}
+
+impl Field {
+    fn label(self, kind: ForwardKind) -> &'static str {
+        match self {
+            Field::Kind => "Type",
+            Field::Bind => "Bind addr",
+            Field::ListenPort => match kind {
+                ForwardKind::Remote => "Remote port",
+                _ => "Local port",
+            },
+            Field::TargetHost => match kind {
+                ForwardKind::Remote => "Local host",
+                _ => "Remote host",
+            },
+            Field::TargetPort => match kind {
+                ForwardKind::Remote => "Local port",
+                _ => "Remote port",
+            },
+        }
+    }
+
+    fn placeholder(self, kind: ForwardKind) -> &'static str {
+        match self {
+            Field::Kind => "←/→ Local · Remote · Dynamic",
+            Field::Bind => "optional · listen interface (default 127.0.0.1)",
+            Field::ListenPort => match kind {
+                ForwardKind::Remote => "required · port to open on the server (e.g. 9090)",
+                ForwardKind::Dynamic => "required · local SOCKS port (e.g. 1080)",
+                ForwardKind::Local => "required · local port to open (e.g. 8080)",
+            },
+            Field::TargetHost => match kind {
+                ForwardKind::Remote => "optional · host reached from here (default localhost)",
+                _ => "optional · host reached from the server (default localhost)",
+            },
+            Field::TargetPort => "required · destination port (e.g. 3306)",
+        }
+    }
+}
+
+/// Fields shown for a kind, in display order.
+fn active_fields(kind: ForwardKind) -> Vec<Field> {
+    let mut v = vec![Field::Kind, Field::Bind, Field::ListenPort];
+    if matches!(kind, ForwardKind::Local | ForwardKind::Remote) {
+        v.push(Field::TargetHost);
+        v.push(Field::TargetPort);
+    }
+    v
+}
+
+pub enum ForwardPopupOutcome {
+    Continue,
+    Cancel,
+    /// Spawn the forward; the app resolves the host (it holds `host_idx`) and runs it.
+    Create {
+        kind: ForwardKind,
+        spec: ForwardSpec,
+    },
+}
+
+pub struct ForwardPopup {
+    host_idx: usize,
+    host_name: String,
+    kind: ForwardKind,
+    focus: usize,
+    bind: TextField,
+    listen_port: TextField,
+    target_host: TextField,
+    target_port: TextField,
+    error: Option<String>,
+}
+
+impl ForwardPopup {
+    pub fn new(host_idx: usize, host_name: String) -> Self {
+        ForwardPopup {
+            host_idx,
+            host_name,
+            kind: ForwardKind::Local,
+            focus: 0,
+            bind: TextField::new(),
+            listen_port: TextField::new(),
+            target_host: TextField::new(),
+            target_port: TextField::new(),
+            error: None,
+        }
+    }
+
+    /// The host this forward is for (the app resolves site defaults + secrets from it).
+    pub fn host_idx(&self) -> usize {
+        self.host_idx
+    }
+
+    /// Re-show the popup with a bind/auth error returned by the spawn attempt.
+    pub fn set_error(&mut self, msg: String) {
+        self.error = Some(msg);
+    }
+
+    fn text_field_mut(&mut self, f: Field) -> Option<&mut TextField> {
+        match f {
+            Field::Bind => Some(&mut self.bind),
+            Field::ListenPort => Some(&mut self.listen_port),
+            Field::TargetHost => Some(&mut self.target_host),
+            Field::TargetPort => Some(&mut self.target_port),
+            Field::Kind => None,
+        }
+    }
+
+    fn text_field(&self, f: Field) -> Option<&TextField> {
+        match f {
+            Field::Bind => Some(&self.bind),
+            Field::ListenPort => Some(&self.listen_port),
+            Field::TargetHost => Some(&self.target_host),
+            Field::TargetPort => Some(&self.target_port),
+            Field::Kind => None,
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> ForwardPopupOutcome {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('s')) {
+            return self.try_create();
+        }
+        let active = active_fields(self.kind);
+        let last = active.len().saturating_sub(1);
+        let focused = active[self.focus.min(last)];
+        match key.code {
+            KeyCode::Esc => return ForwardPopupOutcome::Cancel,
+            KeyCode::Enter => {
+                if self.focus >= last {
+                    return self.try_create();
+                }
+                self.focus += 1;
+            }
+            KeyCode::Tab | KeyCode::Down => self.focus = (self.focus + 1) % active.len(),
+            KeyCode::BackTab | KeyCode::Up => {
+                self.focus = (self.focus + active.len() - 1) % active.len()
+            }
+            code => match focused {
+                Field::Kind => match code {
+                    KeyCode::Left => self.kind = prev_kind(self.kind),
+                    KeyCode::Right | KeyCode::Char(' ') => self.kind = next_kind(self.kind),
+                    _ => {}
+                },
+                f => {
+                    if let Some(tf) = self.text_field_mut(f) {
+                        tf.handle(code);
+                    }
+                }
+            },
+        }
+        // Switching kind may shrink the active set (Dynamic); keep focus in range.
+        let len = active_fields(self.kind).len();
+        if self.focus >= len {
+            self.focus = len - 1;
+        }
+        ForwardPopupOutcome::Continue
+    }
+
+    fn try_create(&mut self) -> ForwardPopupOutcome {
+        let listen_port = match parse_port(&self.listen_port.value) {
+            Ok(p) => p,
+            Err(e) => return self.fail(e, Field::ListenPort),
+        };
+        let bind = nonempty(&self.bind.value);
+        let (target_host, target_port) =
+            if matches!(self.kind, ForwardKind::Local | ForwardKind::Remote) {
+                let tp = match parse_port(&self.target_port.value) {
+                    Ok(p) => p,
+                    Err(e) => return self.fail(e, Field::TargetPort),
+                };
+                (nonempty(&self.target_host.value), Some(tp))
+            } else {
+                (None, None)
+            };
+        let spec = ForwardSpec {
+            bind,
+            listen_port,
+            target_host,
+            target_port,
+        };
+        ForwardPopupOutcome::Create {
+            kind: self.kind,
+            spec,
+        }
+    }
+
+    fn fail(&mut self, msg: &str, field: Field) -> ForwardPopupOutcome {
+        self.error = Some(msg.to_string());
+        if let Some(pos) = active_fields(self.kind).iter().position(|f| *f == field) {
+            self.focus = pos;
+        }
+        ForwardPopupOutcome::Continue
+    }
+}
+
+fn next_kind(k: ForwardKind) -> ForwardKind {
+    let all = ForwardKind::ALL;
+    let i = all.iter().position(|&x| x == k).unwrap_or(0);
+    all[(i + 1) % all.len()]
+}
+fn prev_kind(k: ForwardKind) -> ForwardKind {
+    let all = ForwardKind::ALL;
+    let i = all.iter().position(|&x| x == k).unwrap_or(0);
+    all[(i + all.len() - 1) % all.len()]
+}
+
+fn nonempty(s: &str) -> Option<String> {
+    let t = s.trim();
+    (!t.is_empty()).then(|| t.to_string())
+}
+
+fn parse_port(s: &str) -> Result<u16, &'static str> {
+    let t = s.trim();
+    if t.is_empty() {
+        return Err("port is required");
+    }
+    match t.parse::<u16>() {
+        Ok(0) | Err(_) => Err("port must be a number between 1 and 65535"),
+        Ok(p) => Ok(p),
+    }
+}
+
+pub fn render(frame: &mut Frame, p: &ForwardPopup) {
+    let active = active_fields(p.kind);
+    let width = frame.area().width.saturating_sub(6).clamp(52, 86);
+    let area = centered(frame.area(), width, active.len() as u16 + 7);
+    frame.render_widget(Clear, area);
+
+    let title = format!(" port forward · {} ", p.host_name);
+    let block = Block::default().borders(Borders::ALL).title(title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let accent = Style::default()
+        .fg(super::accent())
+        .add_modifier(Modifier::BOLD);
+    let dim = Style::default().fg(Color::DarkGray);
+
+    for (row, &field) in active.iter().enumerate() {
+        let focused = row == p.focus;
+        let marker = if focused { "▸ " } else { "  " };
+        let label_style = if focused { accent } else { Style::default() };
+        let (value, is_placeholder) = field_value(p, field);
+        let value_style = if is_placeholder {
+            dim
+        } else {
+            Style::default()
+        };
+        let line = Line::from(vec![
+            Span::styled(marker, accent),
+            Span::styled(format!("{:<LABEL_W$} ", field.label(p.kind)), label_style),
+            Span::styled(value, value_style),
+        ]);
+        frame.render_widget(
+            Paragraph::new(line),
+            Rect {
+                x: inner.x,
+                y: inner.y + row as u16,
+                width: inner.width,
+                height: 1,
+            },
+        );
+    }
+
+    let y = inner.y + active.len() as u16 + 1;
+    if let Some(err) = &p.error {
+        frame.render_widget(
+            Paragraph::new(format!("⚠ {err}")).style(Style::default().fg(Color::Red)),
+            Rect {
+                x: inner.x,
+                y,
+                width: inner.width,
+                height: 1,
+            },
+        );
+    }
+    frame.render_widget(
+        Paragraph::new("Tab/↑↓ move · ←/→ change · ↵ next (runs on last) · ^s start · esc cancel")
+            .style(dim),
+        Rect {
+            x: inner.x,
+            y: y + 1,
+            width: inner.width,
+            height: 1,
+        },
+    );
+
+    // Terminal cursor on the focused text field (not the kind chooser).
+    if let Some(&field) = active.get(p.focus)
+        && let Some(tf) = p.text_field(field)
+    {
+        let cx =
+            (inner.x + VALUE_COL + tf.cursor as u16).min(inner.x + inner.width.saturating_sub(1));
+        frame.set_cursor_position((cx, inner.y + p.focus as u16));
+    }
+}
+
+/// (display string, is_placeholder) for a field.
+fn field_value(p: &ForwardPopup, field: Field) -> (String, bool) {
+    match field {
+        Field::Kind => (
+            format!("< {} >    (Local · Remote · Dynamic)", p.kind.label()),
+            false,
+        ),
+        _ => {
+            let tf = p.text_field(field).expect("text field");
+            if tf.value.is_empty() {
+                (field.placeholder(p.kind).to_string(), true)
+            } else {
+                (tf.value.clone(), false)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    fn k(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn local_create_builds_spec() {
+        let mut p = ForwardPopup::new(0, "web".into());
+        p.listen_port = TextField::with("8080");
+        p.target_host = TextField::with("db");
+        p.target_port = TextField::with("3306");
+        match p.try_create() {
+            ForwardPopupOutcome::Create { kind, spec } => {
+                assert_eq!(kind, ForwardKind::Local);
+                assert_eq!(spec.listen_port, 8080);
+                assert_eq!(spec.target_host.as_deref(), Some("db"));
+                assert_eq!(spec.target_port, Some(3306));
+                assert_eq!(spec.bind, None);
+            }
+            _ => panic!("expected Create"),
+        }
+    }
+
+    #[test]
+    fn dynamic_needs_only_listen_port() {
+        let mut p = ForwardPopup::new(0, "web".into());
+        p.kind = ForwardKind::Dynamic;
+        p.listen_port = TextField::with("1080");
+        match p.try_create() {
+            ForwardPopupOutcome::Create { kind, spec } => {
+                assert_eq!(kind, ForwardKind::Dynamic);
+                assert_eq!(spec.listen_port, 1080);
+                assert_eq!(spec.target_port, None);
+            }
+            _ => panic!("expected Create"),
+        }
+    }
+
+    #[test]
+    fn missing_listen_port_keeps_open_with_error() {
+        let mut p = ForwardPopup::new(0, "web".into());
+        assert!(matches!(p.try_create(), ForwardPopupOutcome::Continue));
+        assert!(p.error.is_some());
+    }
+
+    #[test]
+    fn kind_chooser_cycles_and_changes_active_set() {
+        let mut p = ForwardPopup::new(0, "web".into());
+        assert_eq!(p.kind, ForwardKind::Local);
+        assert!(active_fields(p.kind).contains(&Field::TargetHost));
+        p.handle_key(k(KeyCode::Right)); // Local -> Remote
+        assert_eq!(p.kind, ForwardKind::Remote);
+        p.handle_key(k(KeyCode::Right)); // Remote -> Dynamic
+        assert_eq!(p.kind, ForwardKind::Dynamic);
+        assert!(!active_fields(p.kind).contains(&Field::TargetHost));
+    }
+
+    #[test]
+    fn esc_cancels() {
+        let mut p = ForwardPopup::new(0, "web".into());
+        assert!(matches!(
+            p.handle_key(k(KeyCode::Esc)),
+            ForwardPopupOutcome::Cancel
+        ));
+    }
+
+    #[test]
+    fn renders_snapshot() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut p = ForwardPopup::new(0, "prod-db".into());
+        p.listen_port = TextField::with("8080");
+        p.target_host = TextField::with("db");
+        p.target_port = TextField::with("3306");
+
+        let mut term = Terminal::new(TestBackend::new(72, 12)).unwrap();
+        term.draw(|f| render(f, &p)).unwrap();
+        let buf = term.backend().buffer();
+        let width = buf.area.width as usize;
+        let snapshot: String = buf
+            .content()
+            .chunks(width)
+            .map(|row| row.iter().map(|c| c.symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(snapshot.contains("port forward"));
+        assert!(snapshot.contains("prod-db"));
+        assert!(snapshot.contains("Local port"));
+
+        if let Ok(dir) = std::env::var("CARGO_MANIFEST_DIR") {
+            let path = std::path::Path::new(&dir).join("target/forward-popup-snapshot.txt");
+            let _ = std::fs::write(path, &snapshot);
+        }
+    }
+}

--- a/src/ui/forwards.rs
+++ b/src/ui/forwards.rs
@@ -1,0 +1,266 @@
+//! The port-forwards manager (F4): list every active background forward across hosts and stop
+//! any of them. It renders from a snapshot the app refreshes each tick (so a forward that ends —
+//! here, externally, or on its own — drops out live); stopping one returns its id for the app to
+//! kill + remove from the `forwards.json` ledger.
+
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+
+use super::centered;
+use crate::forwards::ForwardEntry;
+use crate::state::now_unix;
+
+pub enum ForwardsOutcome {
+    Continue,
+    Close,
+    /// Stop the forward with this id (the app kills the process + drops it from the ledger).
+    Kill(String),
+}
+
+pub struct ForwardsManager {
+    /// A snapshot of the active forwards, refreshed by the app each tick.
+    forwards: Vec<ForwardEntry>,
+    selected: usize,
+    /// Index pending a stop confirmation, if any.
+    confirm: Option<usize>,
+}
+
+impl ForwardsManager {
+    pub fn new(forwards: Vec<ForwardEntry>) -> Self {
+        ForwardsManager {
+            forwards,
+            selected: 0,
+            confirm: None,
+        }
+    }
+
+    /// Replace the snapshot (called each tick after the app reconciles), keeping the selection
+    /// and any pending confirmation in range.
+    pub fn set_forwards(&mut self, forwards: Vec<ForwardEntry>) {
+        self.forwards = forwards;
+        if self.selected >= self.forwards.len() {
+            self.selected = self.forwards.len().saturating_sub(1);
+        }
+        if let Some(i) = self.confirm
+            && i >= self.forwards.len()
+        {
+            self.confirm = None;
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> ForwardsOutcome {
+        if self.confirm.is_some() {
+            return self.on_confirm_key(key);
+        }
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        match (key.code, ctrl) {
+            (KeyCode::Esc, _) | (KeyCode::Char('c'), true) | (KeyCode::Char('s'), true) => {
+                return ForwardsOutcome::Close;
+            }
+            (KeyCode::Down, false) | (KeyCode::Char('n'), true) => {
+                if !self.forwards.is_empty() && self.selected + 1 < self.forwards.len() {
+                    self.selected += 1;
+                }
+            }
+            (KeyCode::Up, false) | (KeyCode::Char('p'), true) => {
+                self.selected = self.selected.saturating_sub(1);
+            }
+            (KeyCode::Char('d'), false) | (KeyCode::Char('k'), false)
+                if self.selected < self.forwards.len() =>
+            {
+                self.confirm = Some(self.selected);
+            }
+            _ => {}
+        }
+        ForwardsOutcome::Continue
+    }
+
+    fn on_confirm_key(&mut self, key: KeyEvent) -> ForwardsOutcome {
+        let Some(idx) = self.confirm.take() else {
+            return ForwardsOutcome::Continue;
+        };
+        if matches!(key.code, KeyCode::Char('y') | KeyCode::Char('Y'))
+            && let Some(entry) = self.forwards.get(idx)
+        {
+            return ForwardsOutcome::Kill(entry.id.clone());
+        }
+        ForwardsOutcome::Continue
+    }
+}
+
+/// A compact age like `45s`, `12m`, `3h05m` from a start timestamp.
+fn age(started_at: i64) -> String {
+    let secs = (now_unix() - started_at).max(0);
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{}h{:02}m", secs / 3600, (secs % 3600) / 60)
+    }
+}
+
+pub fn render(frame: &mut Frame, m: &ForwardsManager) {
+    let area = centered(
+        frame.area(),
+        frame.area().width.saturating_sub(6).clamp(50, 92),
+        16,
+    );
+    frame.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" port forwards ");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let accent = Style::default().fg(super::accent());
+    let dim = Style::default().fg(Color::DarkGray);
+
+    let rows = ratatui::layout::Layout::vertical([
+        ratatui::layout::Constraint::Min(0),
+        ratatui::layout::Constraint::Length(1),
+    ])
+    .split(inner);
+
+    if m.forwards.is_empty() {
+        frame.render_widget(
+            Paragraph::new("no active port forwards — open one with ^f on a host").style(dim),
+            rows[0],
+        );
+    } else {
+        let host_w = m
+            .forwards
+            .iter()
+            .map(|f| f.host_name.chars().count())
+            .max()
+            .unwrap_or(0)
+            .clamp(6, 20);
+        let items: Vec<ListItem> = m
+            .forwards
+            .iter()
+            .map(|f| {
+                ListItem::new(Line::from(vec![
+                    Span::raw(format!("{:<host_w$}  ", f.host_name)),
+                    Span::raw(f.display.clone()),
+                    Span::styled(format!("   (pid {} · {})", f.pid, age(f.started_at)), dim),
+                ]))
+            })
+            .collect();
+        let list = List::new(items)
+            .highlight_symbol("▸ ")
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+        let mut state = ListState::default();
+        state.select(Some(m.selected.min(m.forwards.len().saturating_sub(1))));
+        frame.render_stateful_widget(list, rows[0], &mut state);
+    }
+
+    if let Some(idx) = m.confirm {
+        let what = m
+            .forwards
+            .get(idx)
+            .map(|f| f.display.as_str())
+            .unwrap_or("");
+        frame.render_widget(
+            Paragraph::new(format!("stop {what}? y = stop · any other key = cancel"))
+                .style(Style::default().fg(Color::Red)),
+            rows[1],
+        );
+    } else {
+        frame.render_widget(
+            Paragraph::new("d/k stop · ↑↓ move · esc close").style(accent),
+            rows[1],
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::forwards::{ForwardKind, ForwardSpec};
+
+    fn k(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn entry(id: &str, pid: i32) -> ForwardEntry {
+        ForwardEntry {
+            id: id.into(),
+            host_id: "h".into(),
+            host_name: "web".into(),
+            kind: ForwardKind::Local,
+            spec: ForwardSpec {
+                bind: None,
+                listen_port: 8080,
+                target_host: Some("db".into()),
+                target_port: Some(3306),
+            },
+            display: "L  127.0.0.1:8080 → db:3306".into(),
+            pid,
+            started_at: now_unix(),
+        }
+    }
+
+    #[test]
+    fn kill_needs_confirmation() {
+        let mut m = ForwardsManager::new(vec![entry("a", 1), entry("b", 2)]);
+        // d opens the confirm; a non-y cancels it with no Kill.
+        m.handle_key(k(KeyCode::Char('d')));
+        assert!(matches!(
+            m.handle_key(k(KeyCode::Char('n'))),
+            ForwardsOutcome::Continue
+        ));
+        // d then y kills the selected (first) entry.
+        m.handle_key(k(KeyCode::Char('d')));
+        match m.handle_key(k(KeyCode::Char('y'))) {
+            ForwardsOutcome::Kill(id) => assert_eq!(id, "a"),
+            _ => panic!("expected Kill"),
+        }
+    }
+
+    #[test]
+    fn esc_closes() {
+        let mut m = ForwardsManager::new(vec![entry("a", 1)]);
+        assert!(matches!(
+            m.handle_key(k(KeyCode::Esc)),
+            ForwardsOutcome::Close
+        ));
+    }
+
+    #[test]
+    fn set_forwards_clamps_selection() {
+        let mut m = ForwardsManager::new(vec![entry("a", 1), entry("b", 2), entry("c", 3)]);
+        m.handle_key(k(KeyCode::Down));
+        m.handle_key(k(KeyCode::Down)); // selected = 2
+        m.set_forwards(vec![entry("a", 1)]); // shrink
+        assert_eq!(m.selected, 0);
+    }
+
+    #[test]
+    fn renders_snapshot() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let m = ForwardsManager::new(vec![entry("a", 4242)]);
+        let mut term = Terminal::new(TestBackend::new(72, 10)).unwrap();
+        term.draw(|f| render(f, &m)).unwrap();
+        let buf = term.backend().buffer();
+        let width = buf.area.width as usize;
+        let snapshot: String = buf
+            .content()
+            .chunks(width)
+            .map(|row| row.iter().map(|c| c.symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(snapshot.contains("port forwards"));
+        assert!(snapshot.contains("web"));
+        assert!(snapshot.contains("pid 4242"));
+
+        if let Ok(dir) = std::env::var("CARGO_MANIFEST_DIR") {
+            let path = std::path::Path::new(&dir).join("target/forwards-manager-snapshot.txt");
+            let _ = std::fs::write(path, &snapshot);
+        }
+    }
+}

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -9,7 +9,7 @@ use super::centered;
 use crate::app::App;
 
 pub fn render(frame: &mut Frame, _app: &App) {
-    let area = centered(frame.area(), 58, 21);
+    let area = centered(frame.area(), 58, 23);
     frame.render_widget(Clear, area);
 
     let lines = vec![
@@ -26,10 +26,12 @@ pub fn render(frame: &mut Frame, _app: &App) {
         Line::from("  ^a / ^e / ^d    add / edit / delete host"),
         Line::from("  ^y              yank the ssh command"),
         Line::from("  ^t              transfer files (SFTP)"),
+        Line::from("  ^f              port forward (runs in the background)"),
         Line::from("  ^o              import from ~/.ssh/config"),
         Line::from("  F1              this help"),
         Line::from("  F2              settings (config & hosts file)"),
         Line::from("  F3              manage sites"),
+        Line::from("  F4              manage port forwards"),
         Line::from("  esc             clear query, then quit"),
         Line::from("  ^c              quit"),
         Line::from(""),

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -177,7 +177,7 @@ fn render_hint(frame: &mut Frame, app: &App, area: Rect) {
         );
         return;
     }
-    let hint = "↵ connect  ^a add  ^e edit  ^d del  ^y yank  ^t transfer  ^o import  F1 help  F2 settings  F3 sites  esc quit";
+    let hint = "↵ connect  ^a add  ^e edit  ^d del  ^y yank  ^t transfer  ^f forward  ^o import  F1 help  F2 settings  F3 sites  F4 forwards  esc quit";
     frame.render_widget(
         Paragraph::new(hint).style(Style::default().fg(Color::DarkGray)),
         area,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,8 @@
 //! ratatui's `TestBackend` (no real terminal needed).
 
 mod browse;
+pub(crate) mod forward_popup;
+pub(crate) mod forwards;
 mod help;
 mod list;
 pub(crate) mod settings;
@@ -85,6 +87,14 @@ pub fn render(frame: &mut Frame, app: &App) {
     }
     if let Some(m) = &app.sites_manager {
         sites::render(frame, m);
+        return;
+    }
+    if let Some(p) = &app.forward_popup {
+        forward_popup::render(frame, p);
+        return;
+    }
+    if let Some(m) = &app.forwards_manager {
+        forwards::render(frame, m);
         return;
     }
     list::render(frame, app);


### PR DESCRIPTION
Start Local (-L), Remote (-R) or Dynamic (-D SOCKS) SSH tunnels from a per-host popup; they run in the background and keep running after sshelf exits. A new manager screen lists every active forward across hosts and stops any of them.

Each forward is one `ssh -N` child spawned in its own process group (std process_group(0), no new deps) with null stdin/stdout, so it survives both sshelf exiting (orphaned, reparented to init) and the terminal closing. Nothing kills a forward on shutdown — that is what keeps it alive. It reuses build_args + the askpass wiring, so keys/agent/ProxyJump/stored passwords and site defaults all work exactly as a normal connect does.

The running processes are the source of truth; forwards.json is just a ledger of PIDs, reconciled against the OS (ps) on launch, on opening the manager, and each tick while it is open — with a zombie filter and a PID-reuse guard so a recycled pid is never counted alive or signalled. ExitOnForwardFailure plus a brief readiness poll surfaces bind/auth failures (port in use, privileged port, server refused, auth) in the popup so the user can fix a field and retry.

New modules forwards.rs, ui/forward_popup.rs and ui/forwards.rs; the throwaway-sshd e2e helper moved to a shared testsupport module so the transfer and forward e2e tests share it. Docs updated (decisions D-021, data-model, ux, structure, README, CHANGELOG).