### PR TITLE
Add interactive 2FA support (verification-code prompt on connect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow SemVer.
 
 ## [Unreleased]
 
+### Added
+- **Two-factor (2FA) hosts** — flag a host (add/edit form, or `sshelf add … --2fa`) whose login
+  needs an interactive verification code (TOTP / keyboard-interactive). On connect, sshelf shows a
+  popup to enter the current code and supplies it to the prompt through the same `SSH_ASKPASS`
+  helper that supplies a stored password — fixing connects that previously failed, because a
+  stored-secret connect runs with `SSH_ASKPASS_REQUIRE=force` (which routes the code prompt to the
+  helper with no terminal fallback). `sshelf <host>` from the CLI prompts on the terminal. Manual
+  entry only — no TOTP seeds are stored. No new dependencies.
+
 ## [0.7.0] — 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,12 +34,15 @@ your editor, and adds things plain SSH config can't express as nicely:
 - **Background port forwarding** (`Ctrl-f`) — start a Local (`-L`), Remote (`-R`) or Dynamic
   (`-D` SOCKS) SSH tunnel that **keeps running after you quit sshelf**. A manager screen (`F4`)
   lists every active forward and stops any; they're reconciled against the OS on each launch.
-- **Guided add/edit form** — hostname, user, port, auth, jump hosts, tags, site, extra args.
+- **Guided add/edit form** — hostname, user, port, auth, jump hosts, tags, site, 2FA, extra args.
 - **Sites** (`F3`) — group hosts (one per host, e.g. a data center) and optionally give the site
   a **shared bastion + default user/port/key** that members inherit at connect time. The list
   groups by site; `site:NAME` filters. Distinct from the many-valued, free-form tags.
 - **Auto-supplied passwords** for password-auth hosts (via `SSH_ASKPASS`; no `sshpass`, the
   secret never appears in `ps`). Stored in your OS keyring, or an encrypted vault.
+- **2FA hosts** — flag a host that wants an interactive verification code (TOTP /
+  keyboard-interactive) and sshelf prompts for it on connect, feeding it through the same askpass
+  channel (manual entry; no stored TOTP seeds).
 - **Jump hosts** (`ProxyJump`), **tags/groups** (`tag:prod`), and **frecency** ordering
   (most-used-recently float to the top).
 - **Read-only import** from `~/.ssh/config` to get started.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -39,6 +39,7 @@ identity_files = ["~/.ssh/infra-key"]   # for auth="key"; repeatable (-i per ent
 jump_hosts = ["bastion.example.com"]    # ProxyJump chain; key/agent auth only in v1
 tags      = ["prod", "db"]    # many-valued, free-form; for filtering/grouping
 site      = "prod-dc"         # optional; one site (by name); groups + inherits its defaults
+requires_2fa = true           # optional (default false); connect prompts for a verification code
 extra_args = "-o ServerAliveInterval=30"  # raw, shlex-split, appended verbatim
 # NOTE: no password field — ever. auth="password" means "look up the secret by id".
 ```
@@ -49,6 +50,9 @@ Notes:
 - `identity_files` / `jump_hosts` / `tags` are `Vec<String>` (empty = absent).
 - `format_version` lets us migrate the schema later without breaking older files. Adding `[[site]]`
   and `host.site` needed **no** bump — old files load with `sites = []` / `site = None`.
+- `requires_2fa` marks a host whose login needs an interactive verification code; connect collects
+  it and passes it to `ssh` via the transient `SSHELF_2FA_CODE` env var (never stored on disk).
+  See [`decisions.md`](./decisions.md) D-022.
 
 ### Sites vs tags, and inheritance
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,6 +5,28 @@ whenever you make a non-trivial design choice.
 
 ---
 
+### D-022 · Interactive 2FA: collect the code before connect, inject it via the askpass helper
+A connect that auto-supplies a stored secret runs `ssh` with `SSH_ASKPASS_REQUIRE=force`, which
+routes **every** interactive prompt — including a server's keyboard-interactive verification-code
+step — to our askpass helper; the helper declined it, and a spike confirmed `force` gives **no
+terminal fallback**, so the code prompt was answered empty and auth failed (a real user hit this).
+A during-session popup is impossible (connect `exec()`s into `ssh`), and a PTY screen-scraper was
+already rejected (D-019). So 2FA is handled the same way the password is: a per-host
+**`requires_2fa`** flag makes connect show a small code popup *before* the `exec()` (while the TUI
+is alive); the entered one-time code is passed to `ssh` via `SSHELF_2FA_CODE` (like the vault
+passphrase already rides env), and the helper answers the **non-secret** prompt with it. The
+helper's routing: a password/passphrase-shaped prompt → the stored secret (unchanged, anti-phish
+guard intact); any other prompt → the queued code; else decline. `configure_askpass` therefore
+force-wires the helper when a secret exists **or** a code is queued (so key+2FA hosts work too).
+The CLI direct-connect path (`sshelf <host>` / `-`), which has no TUI, prompts for the code on the
+terminal before handoff. Rejected: storing the TOTP **seed** and generating the code ourselves
+(puts the second factor in the same vault as the first, and needs a TOTP dep the project avoids);
+auto-detecting 2FA with no flag (we can't probe the server's auth methods without a separate
+non-`exec` connection). Note: a host with **no** stored secret already prompts for the code inline
+after handoff (no askpass forced), so the flag/popup mainly fixes the stored-secret case; an
+encrypted key with no stored passphrase + 2FA should use an agent (else `force` askpass can't
+answer the passphrase prompt either). v1 is manual entry only.
+
 ### D-021 · Port forwards are detached `ssh -N` processes tracked by PID
 Background port forwards (`Ctrl-f` popup, `F4` manager) must keep running after sshelf exits.
 Each forward is **one detached `ssh -N -L|-R|-D <spec>` process**, reusing `ssh::build_args` +

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -3,8 +3,26 @@
 Reverse-chronological. Newest entry on top. Every change to the project adds an entry here
 (the docs-in-sync rule). Keep entries short: what changed, why, and what's next.
 
-**Current milestone:** Port forwarding — background SSH tunnels that outlive sshelf, targeting
-**v0.7.0**. (Sites shipped in v0.6.0.)
+**Current milestone:** Interactive 2FA — prompt for a verification code on connect and inject it
+via the askpass helper, targeting **v0.8.0**. (Port forwarding shipped in v0.7.0.)
+
+---
+
+## 2026-06-23 — Interactive 2FA support
+
+- New: hosts can be flagged **`requires_2fa`** (add/edit form toggle, or `sshelf add … --2fa`).
+  Connecting to one shows a code popup before the `exec()` handoff; the entered one-time code is
+  passed to `ssh` via `SSHELF_2FA_CODE` and answered by the askpass helper at the verification
+  prompt — the same channel that supplies a stored password.
+- Why: a spike confirmed that a stored-secret connect runs with `SSH_ASKPASS_REQUIRE=force`, which
+  routes the keyboard-interactive code prompt to our helper with **no** terminal fallback, so it
+  failed before. The helper now answers a non-secret prompt with the queued code; `configure_askpass`
+  force-wires the helper when a secret exists **or** a code is queued (so key+2FA works too). The
+  CLI direct-connect path prompts for the code on the terminal.
+- New module `ui/two_factor.rs`; `Host.requires_2fa` (old files load `false`); `exec_connect` /
+  `configure_askpass` take an optional code (transfer + forward spawners pass `None`). Manual entry
+  only — no TOTP seeds stored (rejected: same-vault second factor + a dep). Docs synced (decisions
+  D-022, data-model, ux, structure, README, CHANGELOG). Targets **v0.8.0** via `feat/two-factor`.
 
 ---
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -5,7 +5,7 @@
 > **All modules present:** `main`, `app`, `askpass`, `config`, `forwards`, `import`, `model`,
 > `paths`, `search`, `secrets`, `ssh`, `state`, `store`, `transfer/{mod,worker,pane,screen,e2e}`,
 > `testsupport` (test-only), `vault`,
-> `ui/{mod,list,help,widgets,wizard,browse,settings,sites,transfer,forward_popup,forwards}`.
+> `ui/{mod,list,help,widgets,wizard,browse,settings,sites,transfer,forward_popup,forwards,two_factor}`.
 > (`error.rs` was removed — the codebase uses `anyhow` throughout.)
 
 ## Repository
@@ -34,7 +34,7 @@ ssh-tui/                 (crate/binary name: `sshelf`)
 | `forwards.rs` | Background port-forwards: the `ForwardSpec`/`ForwardEntry` model, the `-L/-R/-D` argv builder, spawn (detached `ssh -N` + readiness/error mapping), PID liveness/kill via `ps`/`kill`, reconcile, and `forwards.json` load/save. |
 | `secrets.rs` | `SecretStore` trait → keyring backend + `age`-vault fallback; `zeroize` on secrets. |
 | `ssh.rs` | Build `ssh` argv from a `Host`; terminal teardown + `exec()` handoff; askpass env wiring. |
-| `askpass.rs` | Headless askpass entry: inspect `argv[1]`; answer only password prompts via `secrets`. |
+| `askpass.rs` | Headless askpass entry: inspect `argv[1]`; answer password prompts via `secrets`, or a queued 2FA code (`SSHELF_2FA_CODE`) for the verification prompt; else decline. |
 | `search.rs` | Fuzzy filter (`nucleo-matcher`) + frecency ranking + per-row match indices for highlight. |
 | `import.rs` | `ssh2-config` parse of `~/.ssh/config` → `Host` mapping; warn on unsupported `Match`/`Include`. |
 | `paths.rs` | `etcetera` path resolution (config/data dirs); file paths; dir/file perms (`0700`/`0600`). |
@@ -51,6 +51,7 @@ ssh-tui/                 (crate/binary name: `sshelf`)
 | `ui/sites.rs` | Sites manager (F3): list + add/edit/delete sites and their optional defaults; emits renames for the app to cascade. |
 | `ui/forward_popup.rs` | New-port-forward popup (Ctrl-f): kind chooser (Local/Remote/Dynamic) + ports/host fields + validation; emits a `ForwardSpec` for the app to spawn. |
 | `ui/forwards.rs` | Port-forwards manager (F4): lists all active forwards from a live snapshot; emits a kill request for the app to act on. |
+| `ui/two_factor.rs` | 2FA code popup shown before connecting to a `requires_2fa` host; emits the entered code for the app to queue + supply via askpass. |
 | `ui/help.rs` | Help overlay. |
 | `ui/widgets.rs` | Shared widgets: single-line text input (hand-rolled), keybind hint bar, confirm modal. |
 

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -67,7 +67,8 @@ A single full-screen form (`Ctrl-a` add, `Ctrl-e` edit selected). Every field sh
 to the chosen Auth method, so the rest don't clutter the screen.
 
 Always shown: **Name** (required), **Hostname** (required), **User** (defaults `$USER`),
-**Port** (defaults 22), **Auth**, **Jump hosts**, **Tags**, **Extra args** (raw flags escape hatch).
+**Port** (defaults 22), **Auth**, **Jump hosts**, **Tags**, **Site**, **2FA** (`←`/`→` yes/no —
+prompt for a verification code on connect), **Extra args** (raw flags escape hatch).
 
 Auth-specific fields:
 
@@ -199,6 +200,22 @@ another terminal, or dropped on its own (sleep / network) — disappears within 
 **survive sshelf exiting** (each is a detached process in its own process group) and the ledger
 (`forwards.json`) is reconciled against the running processes on every launch, so you only ever
 see forwards that are still actually running. See [`decisions.md`](decisions.md) D-021.
+
+## Two-factor (2FA) hosts
+
+Some servers want an interactive verification code (TOTP / keyboard-interactive) on top of your
+key or password. Mark such a host with **2FA = yes** in the add/edit form (or `sshelf add …
+--2fa`). On connect, sshelf shows a small popup to enter the current code **before** handing off
+to `ssh`, and supplies it to the verification prompt through the same askpass helper that supplies
+your stored password — sshelf never proxies the live session.
+
+The flag is needed because a connect that auto-supplies a stored secret runs `ssh` with
+`SSH_ASKPASS_REQUIRE=force`, which routes the code prompt to the helper with no terminal fallback —
+so without it the connect would simply fail. (A host with **no** stored secret already prompts for
+the code inline after handoff, so the flag mainly matters for stored-secret hosts; a host using an
+encrypted key with no stored passphrase should use an agent.) `sshelf <host>` from the CLI (no TUI)
+prompts for the code on the terminal instead. v1 is manual entry — sshelf does **not** store TOTP
+seeds. See [`decisions.md`](decisions.md) D-022.
 
 ## CLI (outside the TUI)
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,6 +29,7 @@ use crate::ui::forward_popup::{ForwardPopup, ForwardPopupOutcome};
 use crate::ui::forwards::{ForwardsManager, ForwardsOutcome};
 use crate::ui::settings::{Settings, SettingsOutcome};
 use crate::ui::sites::{SitesManager, SitesOutcome};
+use crate::ui::two_factor::{TwoFactorOutcome, TwoFactorPopup};
 use crate::ui::wizard::{Wizard, WizardOutcome};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -85,6 +86,10 @@ pub struct App {
     pub forwards_manager: Option<ForwardsManager>,
     /// Active background port-forwards (the `forwards.json` ledger).
     pub forwards_state: ForwardsState,
+    /// The 2FA verification-code popup, shown before connecting to a `requires_2fa` host.
+    pub two_factor: Option<TwoFactorPopup>,
+    /// A one-time 2FA code collected for the pending connect; passed to `ssh` after teardown.
+    pub pending_2fa_code: Option<String>,
     /// The dual-pane file-transfer screen, when open.
     pub transfer: Option<transfer::TransferScreen>,
     /// Transient status line (cleared on next keypress).
@@ -121,6 +126,8 @@ impl App {
             forward_popup: None,
             forwards_manager: None,
             forwards_state: ForwardsState::default(),
+            two_factor: None,
+            pending_2fa_code: None,
             transfer: None,
             status: None,
             should_quit: false,
@@ -207,6 +214,10 @@ impl App {
         }
         if self.forwards_manager.is_some() {
             self.on_key_forwards(key);
+            return Outcome::Continue;
+        }
+        if self.two_factor.is_some() {
+            self.on_key_two_factor(key);
             return Outcome::Continue;
         }
         match self.screen {
@@ -535,6 +546,32 @@ impl App {
         }
     }
 
+    /// Open the 2FA code popup for `idx` (a `requires_2fa` host). On submit it queues the code +
+    /// the pending connect and quits, so the real `exec()` happens after terminal restore.
+    fn open_two_factor(&mut self, idx: usize) {
+        self.two_factor = Some(TwoFactorPopup::new(idx, self.hosts[idx].name.clone()));
+    }
+
+    fn on_key_two_factor(&mut self, key: KeyEvent) {
+        let outcome = match self.two_factor.as_mut() {
+            Some(p) => p.handle_key(key),
+            None => return,
+        };
+        match outcome {
+            TwoFactorOutcome::Continue => {}
+            TwoFactorOutcome::Cancel => self.two_factor = None,
+            TwoFactorOutcome::Submit(code) => {
+                let idx = self.two_factor.as_ref().map(TwoFactorPopup::host_idx);
+                self.two_factor = None;
+                if let Some(idx) = idx {
+                    self.pending_2fa_code = Some(code);
+                    self.pending_connect = Some(idx);
+                    self.should_quit = true;
+                }
+            }
+        }
+    }
+
     /// Open the new-port-forward popup for `idx`. Called from the loop (mirrors `open_transfer`).
     fn open_forward_popup(&mut self, idx: usize) {
         self.forward_popup = Some(ForwardPopup::new(idx, self.hosts[idx].name.clone()));
@@ -714,8 +751,10 @@ fn run_with(start_add: bool) -> Result<()> {
             .ok()
             .flatten()
             .is_some();
-        // Replaces this process on success; returns only on failure.
-        return Err(ssh::exec_connect(&host, has_secret));
+        // Replaces this process on success; returns only on failure. A 2FA code, if the user
+        // entered one in the popup, rides through the askpass helper.
+        let two_fa = app.pending_2fa_code.as_deref();
+        return Err(ssh::exec_connect(&host, has_secret, two_fa));
     }
     Ok(())
 }
@@ -747,8 +786,13 @@ fn dispatch(app: &mut App, key: KeyEvent) {
     match app.on_key(key) {
         Outcome::Quit => app.should_quit = true,
         Outcome::Connect(idx) => {
-            app.pending_connect = Some(idx);
-            app.should_quit = true;
+            if app.hosts[idx].requires_2fa {
+                // Collect the verification code first; the connect happens on the popup's submit.
+                app.open_two_factor(idx);
+            } else {
+                app.pending_connect = Some(idx);
+                app.should_quit = true;
+            }
         }
         Outcome::Yank(idx) => {
             let cmd = ssh::command_string(&app.hosts[idx].with_site_defaults(&app.sites));
@@ -898,6 +942,53 @@ mod tests {
             app.on_key(ctrl(KeyCode::Char('t'))),
             Outcome::Transfer(expected)
         );
+    }
+
+    #[test]
+    fn connecting_to_2fa_host_opens_code_popup_instead() {
+        let mut app = test_app();
+        let sel = app.order[app.selected];
+        app.hosts[sel].requires_2fa = true;
+        dispatch(&mut app, key(KeyCode::Enter));
+        assert!(
+            app.two_factor.is_some(),
+            "a 2FA host should open the code popup"
+        );
+        assert!(!app.should_quit);
+        assert!(app.pending_connect.is_none());
+    }
+
+    #[test]
+    fn connecting_to_normal_host_skips_the_popup() {
+        let mut app = test_app();
+        dispatch(&mut app, key(KeyCode::Enter));
+        assert!(app.two_factor.is_none());
+        assert!(app.should_quit);
+        assert!(app.pending_connect.is_some());
+    }
+
+    #[test]
+    fn two_factor_submit_queues_code_and_connects() {
+        let mut app = test_app();
+        app.open_two_factor(1);
+        for c in "654321".chars() {
+            app.on_key(key(KeyCode::Char(c)));
+        }
+        app.on_key(key(KeyCode::Enter));
+        assert!(app.two_factor.is_none());
+        assert_eq!(app.pending_connect, Some(1));
+        assert_eq!(app.pending_2fa_code.as_deref(), Some("654321"));
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn two_factor_esc_cancels_without_connecting() {
+        let mut app = test_app();
+        app.open_two_factor(0);
+        app.on_key(key(KeyCode::Esc));
+        assert!(app.two_factor.is_none());
+        assert!(app.pending_connect.is_none());
+        assert!(app.pending_2fa_code.is_none());
     }
 
     #[test]

--- a/src/askpass.rs
+++ b/src/askpass.rs
@@ -1,21 +1,63 @@
 //! Headless `SSH_ASKPASS` helper mode.
 //!
-//! `ssh` invokes us as `sshelf "<prompt>"` (with `SSHELF_ASKPASS=1` in the environment). We
-//! answer **only** password prompts — fetching the secret for `SSHELF_HOST_ID` — and decline
-//! everything else (host-key `yes/no`, key passphrases, OTP) by exiting non-zero, so ssh
-//! handles those itself. This split is mandatory because `SSH_ASKPASS_REQUIRE=force` routes
-//! *every* prompt here (proven by the M0 spike — see docs/ssh-command.md).
+//! `ssh` invokes us as `sshelf "<prompt>"` (with `SSHELF_ASKPASS=1` in the environment). Because
+//! a connect that auto-supplies a stored secret runs with `SSH_ASKPASS_REQUIRE=force`, *every*
+//! interactive prompt is routed here (proven by the M0 spikes — see docs/ssh-command.md), and a
+//! prompt we decline is NOT retried on the terminal — it simply fails. So we answer:
+//!   - **password/passphrase** prompts → the stored secret for `SSHELF_HOST_ID`;
+//!   - any **other** prompt → the one-time 2FA code in `SSHELF_2FA_CODE`, if one was queued for
+//!     this connection (the user entered it just before connecting);
+//!   - otherwise we decline (exit non-zero) — e.g. an unexpected prompt with no code queued.
 
 use crate::paths::Paths;
 use crate::secrets;
 
 const HOST_ID_ENV: &str = "SSHELF_HOST_ID";
+/// Env var carrying a one-time verification code the user entered for this connection.
+pub(crate) const CODE_ENV: &str = "SSHELF_2FA_CODE";
+
+/// What a given prompt should be answered with (decided without IO, so it's unit-testable).
+#[derive(Debug, PartialEq, Eq)]
+enum Answer {
+    /// The stored login password / key passphrase.
+    Secret,
+    /// The queued one-time 2FA code.
+    Code,
+    /// Nothing — decline.
+    Decline,
+}
+
+/// Decide how to answer `prompt`. A password/passphrase prompt always takes the stored secret;
+/// any other prompt takes the queued code when one is present (the user opted into 2FA for this
+/// connection, so a non-secret prompt is the verification step). Host-key prompts never reach
+/// here in practice — connect passes `StrictHostKeyChecking=accept-new`.
+fn classify(prompt: &str, has_code: bool) -> Answer {
+    if is_secret_prompt(prompt) {
+        Answer::Secret
+    } else if has_code {
+        Answer::Code
+    } else {
+        Answer::Decline
+    }
+}
 
 /// Run askpass mode for the given prompt; returns the process exit code.
 pub fn run(prompt: &str) -> i32 {
-    if !is_secret_prompt(prompt) {
-        return 1; // decline; let ssh handle it
+    let code = std::env::var(CODE_ENV).ok().filter(|c| !c.is_empty());
+    match classify(prompt, code.is_some()) {
+        Answer::Secret => supply_secret(),
+        Answer::Code => {
+            let code = zeroize::Zeroizing::new(code.unwrap_or_default());
+            // ssh reads one line and strips the trailing newline.
+            println!("{}", code.as_str());
+            0
+        }
+        Answer::Decline => 1,
     }
+}
+
+/// Look up and print the stored secret for `SSHELF_HOST_ID`; exit code per success.
+fn supply_secret() -> i32 {
     let Ok(id) = std::env::var(HOST_ID_ENV) else {
         return 1;
     };
@@ -28,7 +70,6 @@ pub fn run(prompt: &str) -> i32 {
     match secrets::get_password(&paths.vault_file(), &id) {
         Ok(Some(pw)) => {
             let pw = zeroize::Zeroizing::new(pw);
-            // ssh reads one line and strips the trailing newline.
             println!("{}", pw.as_str());
             0
         }
@@ -76,5 +117,21 @@ mod tests {
             "Please confirm your password for this operation:"
         ));
         assert!(!is_secret_prompt("Type your password to continue:"));
+    }
+
+    #[test]
+    fn classify_routes_password_code_and_decline() {
+        // A password/passphrase prompt always takes the stored secret, code queued or not.
+        assert_eq!(classify("tester@host's password: ", true), Answer::Secret);
+        assert_eq!(
+            classify("Enter passphrase for key '/k': ", false),
+            Answer::Secret
+        );
+        // The 2FA verification prompt takes the queued code…
+        assert_eq!(classify("Verification code: ", true), Answer::Code);
+        // …but with no code queued, a non-secret prompt is declined (the old behavior).
+        assert_eq!(classify("Verification code: ", false), Answer::Decline);
+        // A second/unknown prompt during a 2FA connect still gets the (one) queued code.
+        assert_eq!(classify("One-time password (OATH): ", true), Answer::Code);
     }
 }

--- a/src/forwards.rs
+++ b/src/forwards.rs
@@ -258,7 +258,7 @@ pub fn spawn_forward(
 
     let mut cmd = Command::new("ssh");
     cmd.args(build_forward_command(host, kind, &spec));
-    ssh::configure_askpass(&mut cmd, host, has_secret);
+    ssh::configure_askpass(&mut cmd, host, has_secret, None);
     cmd.process_group(0) // own process group → survives terminal close
         .stdin(Stdio::null())
         .stdout(Stdio::null())

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,6 +174,9 @@ struct AddArgs {
     /// keeping the secret out of argv and shell history. Implies `--auth password`.
     #[arg(long)]
     password_stdin: bool,
+    /// The host's login needs an interactive verification code (2FA): connect prompts for it.
+    #[arg(long = "2fa")]
+    requires_2fa: bool,
 }
 
 /// CLI spelling of the auth method, kept separate from `model::AuthMethod` so the model stays
@@ -210,6 +213,7 @@ impl AddArgs {
             || self.site.is_some()
             || self.extra_args.is_some()
             || self.password_stdin
+            || self.requires_2fa
     }
 
     /// Effective auth method, with inference from --identity / --password-stdin.
@@ -240,6 +244,7 @@ impl AddArgs {
         host.tags = self.tags;
         host.site = self.site;
         host.extra_args = self.extra_args;
+        host.requires_2fa = self.requires_2fa;
         Ok(host)
     }
 }
@@ -667,7 +672,27 @@ fn connect(host: &Host, paths: &Paths) -> Result<()> {
         .flatten()
         .is_some();
     // Replaces this process on success; returns only on failure.
-    Err(ssh::exec_connect(host, has_secret))
+    let code = prompt_2fa_code(host);
+    Err(ssh::exec_connect(host, has_secret, code.as_deref()))
+}
+
+/// For a host flagged `requires_2fa`, prompt on the terminal for the one-time code before the
+/// `exec()` handoff (the CLI has no TUI popup). Returns `None` for non-2FA hosts or on read error.
+fn prompt_2fa_code(host: &Host) -> Option<String> {
+    if !host.requires_2fa {
+        return None;
+    }
+    use std::io::Write;
+    eprint!("Verification code for {}: ", host.name);
+    let _ = std::io::stderr().flush();
+    let mut line = String::new();
+    match std::io::stdin().read_line(&mut line) {
+        Ok(n) if n > 0 => {
+            let code = line.trim().to_string();
+            (!code.is_empty()).then_some(code)
+        }
+        _ => None,
+    }
 }
 
 /// Find a host by exact name or id.

--- a/src/model.rs
+++ b/src/model.rs
@@ -100,6 +100,16 @@ pub struct Host {
     /// inherited defaults; an undefined name degrades to pure grouping (no inheritance).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub site: Option<String>,
+    /// The login needs an interactive second factor (a keyboard-interactive verification code,
+    /// e.g. TOTP). When set, connect prompts for the code first and supplies it to `ssh` via the
+    /// askpass helper. Required because a connect that auto-supplies a stored secret runs with
+    /// `SSH_ASKPASS_REQUIRE=force`, which otherwise can't answer the code prompt. See D-022.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub requires_2fa: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 impl Host {
@@ -117,6 +127,7 @@ impl Host {
             tags: Vec::new(),
             extra_args: None,
             site: None,
+            requires_2fa: false,
         }
     }
 

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -79,44 +79,58 @@ pub fn command_string(host: &Host) -> String {
 /// error only if the exec itself fails (e.g. `ssh` not found). The caller must have already
 /// restored the terminal.
 #[cfg(unix)]
-pub fn exec_connect(host: &Host, wire_askpass: bool) -> anyhow::Error {
+pub fn exec_connect(host: &Host, wire_askpass: bool, two_fa_code: Option<&str>) -> anyhow::Error {
     use std::os::unix::process::CommandExt;
     let args = build_args(host, true);
     let mut cmd = std::process::Command::new("ssh");
     cmd.args(&args);
-    configure_askpass(&mut cmd, host, wire_askpass);
+    configure_askpass(&mut cmd, host, wire_askpass, two_fa_code);
     // exec() returns only on failure.
     anyhow::anyhow!("failed to launch ssh: {}", cmd.exec())
 }
 
 #[cfg(not(unix))]
-pub fn exec_connect(host: &Host, wire_askpass: bool) -> anyhow::Error {
+pub fn exec_connect(host: &Host, wire_askpass: bool, two_fa_code: Option<&str>) -> anyhow::Error {
     // No process-replacement on non-unix; spawn + wait, then mirror the exit code.
     let args = build_args(host, true);
     let mut cmd = std::process::Command::new("ssh");
     cmd.args(&args);
-    configure_askpass(&mut cmd, host, wire_askpass);
+    configure_askpass(&mut cmd, host, wire_askpass, two_fa_code);
     match cmd.status() {
         Ok(status) => std::process::exit(status.code().unwrap_or(1)),
         Err(e) => anyhow::anyhow!("failed to launch ssh: {e}"),
     }
 }
 
-/// Wire our own binary as the `SSH_ASKPASS` helper so the stored secret (a login password OR
-/// a key passphrase) is supplied automatically. Only when `wire_askpass` is set (a secret
-/// exists); otherwise clear any inherited askpass so ssh prompts / uses the agent normally.
+/// Wire our own binary as the `SSH_ASKPASS` helper so the stored secret (a login password OR a
+/// key passphrase) and/or a queued one-time 2FA code are supplied automatically. The helper is
+/// wired (with `SSH_ASKPASS_REQUIRE=force`) when there's a secret to supply (`wire_askpass`) OR a
+/// `two_fa_code` to inject; otherwise any inherited askpass is cleared so ssh prompts / uses the
+/// agent normally.
 ///
-/// Reused by the transfer worker to authenticate the ControlMaster exactly as connect does.
-pub(crate) fn configure_askpass(cmd: &mut std::process::Command, host: &Host, wire_askpass: bool) {
+/// Reused by the transfer worker + the port-forward spawner to authenticate exactly as connect
+/// does (they pass `two_fa_code: None`).
+pub(crate) fn configure_askpass(
+    cmd: &mut std::process::Command,
+    host: &Host,
+    wire_askpass: bool,
+    two_fa_code: Option<&str>,
+) {
     cmd.env_remove("SSH_ASKPASS")
-        .env_remove("SSH_ASKPASS_REQUIRE");
+        .env_remove("SSH_ASKPASS_REQUIRE")
+        .env_remove(crate::askpass::CODE_ENV);
     if !wire_askpass {
-        // No stored secret → the askpass helper never runs, so the exec'd ssh has no
-        // business inheriting the vault master passphrase (it may be exported in the
-        // shell for headless use). In the wired case it must stay: the helper runs as
-        // ssh's child and reads it to unlock the vault (see docs/ssh-command.md).
+        // No stored secret → the exec'd ssh (and our helper) has no business inheriting the
+        // vault master passphrase (it may be exported in the shell for headless use). In the
+        // wired case it must stay: the helper runs as ssh's child and reads it to unlock the
+        // vault (see docs/ssh-command.md). A 2FA-only wire still scrubs it (no secret lookup).
         cmd.env_remove(crate::secrets::VAULT_PASS_ENV);
+    }
+    if !wire_askpass && two_fa_code.is_none() {
         return;
+    }
+    if let Some(code) = two_fa_code {
+        cmd.env(crate::askpass::CODE_ENV, code);
     }
     if let Ok(exe) = std::env::current_exe() {
         cmd.env("SSH_ASKPASS", exe)
@@ -225,7 +239,7 @@ mod tests {
     fn vault_env_scrubbed_when_askpass_not_wired() {
         let h = Host::new("a", "h");
         let mut cmd = std::process::Command::new("ssh");
-        configure_askpass(&mut cmd, &h, false);
+        configure_askpass(&mut cmd, &h, false, None);
         // env_remove shows up as (key, None) in get_envs()
         let scrubbed = cmd
             .get_envs()
@@ -234,13 +248,18 @@ mod tests {
             scrubbed,
             "vault passphrase must not leak into a no-askpass ssh"
         );
+        // And no askpass is wired.
+        assert!(
+            !cmd.get_envs()
+                .any(|(k, v)| k == std::ffi::OsStr::new("SSHELF_ASKPASS") && v.is_some())
+        );
     }
 
     #[test]
     fn vault_env_kept_when_askpass_wired() {
         let h = Host::new("a", "h");
         let mut cmd = std::process::Command::new("ssh");
-        configure_askpass(&mut cmd, &h, true);
+        configure_askpass(&mut cmd, &h, true, None);
         // Wired: the helper (ssh's child) needs the env var to unlock the vault.
         let scrubbed = cmd
             .get_envs()
@@ -250,5 +269,30 @@ mod tests {
             .get_envs()
             .any(|(k, v)| k == std::ffi::OsStr::new("SSHELF_ASKPASS") && v.is_some());
         assert!(wired);
+    }
+
+    #[test]
+    fn two_fa_code_wires_askpass_and_sets_code_env() {
+        let h = Host::new("a", "h");
+        let mut cmd = std::process::Command::new("ssh");
+        // No stored secret, but a 2FA code is queued (e.g. a key+2FA host).
+        configure_askpass(&mut cmd, &h, false, Some("123456"));
+        // The helper is wired so it can answer the verification-code prompt…
+        assert!(
+            cmd.get_envs()
+                .any(|(k, v)| k == std::ffi::OsStr::new("SSHELF_ASKPASS") && v.is_some())
+        );
+        // …the code rides in SSHELF_2FA_CODE…
+        assert!(
+            cmd.get_envs()
+                .any(|(k, v)| k == std::ffi::OsStr::new(crate::askpass::CODE_ENV)
+                    && v == Some(std::ffi::OsStr::new("123456")))
+        );
+        // …and with no stored secret the vault passphrase is still scrubbed.
+        assert!(
+            cmd.get_envs()
+                .any(|(k, v)| v.is_none()
+                    && k == std::ffi::OsStr::new(crate::secrets::VAULT_PASS_ENV))
+        );
     }
 }

--- a/src/transfer/worker.rs
+++ b/src/transfer/worker.rs
@@ -193,7 +193,7 @@ fn run(host: Host, has_secret: bool, cmd_rx: Receiver<WorkerCmd>, events: Sender
 fn open_master(host: &Host, has_secret: bool, socket: &Path) -> std::io::Result<Child> {
     let mut cmd = Command::new("ssh");
     cmd.args(master_args(host, socket));
-    ssh::configure_askpass(&mut cmd, host, has_secret);
+    ssh::configure_askpass(&mut cmd, host, has_secret, None);
     cmd.stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped()); // kept so a failed handshake can explain itself

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,6 +9,7 @@ mod list;
 pub(crate) mod settings;
 pub(crate) mod sites;
 mod transfer;
+pub(crate) mod two_factor;
 mod widgets;
 pub(crate) mod wizard;
 
@@ -95,6 +96,10 @@ pub fn render(frame: &mut Frame, app: &App) {
     }
     if let Some(m) = &app.forwards_manager {
         forwards::render(frame, m);
+        return;
+    }
+    if let Some(p) = &app.two_factor {
+        two_factor::render(frame, p);
         return;
     }
     list::render(frame, app);

--- a/src/ui/two_factor.rs
+++ b/src/ui/two_factor.rs
@@ -1,0 +1,189 @@
+//! The 2FA verification-code popup, shown just before connecting to a host flagged
+//! `requires_2fa`. The code is collected here — while the TUI is still alive — and handed to the
+//! exec'd `ssh` through the askpass helper; sshelf never proxies the live session. See D-022.
+
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use super::centered;
+use super::widgets::TextField;
+
+const LABEL: &str = "Verification code: ";
+
+pub enum TwoFactorOutcome {
+    Continue,
+    Cancel,
+    /// Connect now, supplying this one-time code to the verification prompt.
+    Submit(String),
+}
+
+pub struct TwoFactorPopup {
+    host_idx: usize,
+    host_name: String,
+    code: TextField,
+    error: Option<String>,
+}
+
+impl TwoFactorPopup {
+    pub fn new(host_idx: usize, host_name: String) -> Self {
+        TwoFactorPopup {
+            host_idx,
+            host_name,
+            code: TextField::new(),
+            error: None,
+        }
+    }
+
+    /// The host this code is for (the app resolves it back to a connect).
+    pub fn host_idx(&self) -> usize {
+        self.host_idx
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> TwoFactorOutcome {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
+            return TwoFactorOutcome::Cancel;
+        }
+        match key.code {
+            KeyCode::Esc => return TwoFactorOutcome::Cancel,
+            KeyCode::Enter => {
+                let code = self.code.value.trim().to_string();
+                if code.is_empty() {
+                    self.error = Some("enter the verification code".into());
+                } else {
+                    return TwoFactorOutcome::Submit(code);
+                }
+            }
+            code => {
+                self.code.handle(code);
+            }
+        }
+        TwoFactorOutcome::Continue
+    }
+}
+
+pub fn render(frame: &mut Frame, p: &TwoFactorPopup) {
+    let width = frame.area().width.saturating_sub(6).clamp(46, 74);
+    let area = centered(frame.area(), width, 7);
+    frame.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" 2FA · {} ", p.host_name));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let dim = Style::default().fg(Color::DarkGray);
+    let accent = Style::default()
+        .fg(super::accent())
+        .add_modifier(Modifier::BOLD);
+
+    let value = if p.code.value.is_empty() {
+        Span::styled("the code your authenticator app shows", dim)
+    } else {
+        Span::raw(p.code.value.clone())
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(LABEL, accent), value])),
+        Rect {
+            x: inner.x,
+            y: inner.y,
+            width: inner.width,
+            height: 1,
+        },
+    );
+
+    if let Some(err) = &p.error {
+        frame.render_widget(
+            Paragraph::new(format!("⚠ {err}")).style(Style::default().fg(Color::Red)),
+            Rect {
+                x: inner.x,
+                y: inner.y + 2,
+                width: inner.width,
+                height: 1,
+            },
+        );
+    }
+
+    frame.render_widget(
+        Paragraph::new("↵ connect · esc cancel").style(dim),
+        Rect {
+            x: inner.x,
+            y: inner.y + inner.height.saturating_sub(1),
+            width: inner.width,
+            height: 1,
+        },
+    );
+
+    let col = (inner.x + LABEL.chars().count() as u16 + p.code.cursor as u16)
+        .min(inner.x + inner.width.saturating_sub(1));
+    frame.set_cursor_position((col, inner.y));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn k(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+    fn type_str(p: &mut TwoFactorPopup, s: &str) {
+        for c in s.chars() {
+            p.handle_key(k(KeyCode::Char(c)));
+        }
+    }
+
+    #[test]
+    fn submit_returns_the_code() {
+        let mut p = TwoFactorPopup::new(2, "vpn".into());
+        type_str(&mut p, "654321");
+        match p.handle_key(k(KeyCode::Enter)) {
+            TwoFactorOutcome::Submit(code) => assert_eq!(code, "654321"),
+            _ => panic!("expected Submit"),
+        }
+        assert_eq!(p.host_idx(), 2);
+    }
+
+    #[test]
+    fn empty_enter_keeps_open_with_error() {
+        let mut p = TwoFactorPopup::new(0, "vpn".into());
+        assert!(matches!(
+            p.handle_key(k(KeyCode::Enter)),
+            TwoFactorOutcome::Continue
+        ));
+        assert!(p.error.is_some());
+    }
+
+    #[test]
+    fn esc_cancels() {
+        let mut p = TwoFactorPopup::new(0, "vpn".into());
+        assert!(matches!(
+            p.handle_key(k(KeyCode::Esc)),
+            TwoFactorOutcome::Cancel
+        ));
+    }
+
+    #[test]
+    fn renders_snapshot() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut p = TwoFactorPopup::new(0, "prod-vpn".into());
+        type_str(&mut p, "123456");
+        let mut term = Terminal::new(TestBackend::new(60, 9)).unwrap();
+        term.draw(|f| render(f, &p)).unwrap();
+        let buf = term.backend().buffer();
+        let width = buf.area.width as usize;
+        let snapshot: String = buf
+            .content()
+            .chunks(width)
+            .map(|row| row.iter().map(|c| c.symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(snapshot.contains("2FA · prod-vpn"));
+        assert!(snapshot.contains("Verification code:"));
+        assert!(snapshot.contains("123456"));
+    }
+}

--- a/src/ui/wizard.rs
+++ b/src/ui/wizard.rs
@@ -40,6 +40,7 @@ enum Field {
     JumpHosts,
     Tags,
     Site,
+    TwoFactor,
     ExtraArgs,
 }
 
@@ -62,6 +63,7 @@ impl Field {
             Field::JumpHosts => "Jump hosts",
             Field::Tags => "Tags",
             Field::Site => "Site",
+            Field::TwoFactor => "2FA",
             Field::ExtraArgs => "Extra args",
         }
     }
@@ -84,6 +86,7 @@ impl Field {
             Field::JumpHosts => "optional · ProxyJump chain, e.g. bastion,host2",
             Field::Tags => "optional · labels, space/comma separated, e.g. prod db",
             Field::Site => "←/→ choose a site · (none) = no site · manage with F3",
+            Field::TwoFactor => "←/→ · prompt for a verification code on connect (TOTP/2FA)",
             Field::ExtraArgs => "optional · extra ssh flags, e.g. -o BatchMode=yes",
         }
     }
@@ -240,6 +243,8 @@ pub struct Wizard {
     jump: TextField,
     tags: TextField,
     site: SitePicker,
+    /// Whether this host's login requires an interactive verification code (2FA).
+    two_factor: bool,
     extra: TextField,
     /// File browser modal, open when the user is picking a key file.
     browser: Option<FileBrowser>,
@@ -272,6 +277,7 @@ impl Wizard {
         w.jump = TextField::with(h.jump_hosts.join(", "));
         w.tags = TextField::with(h.tags.join(", "));
         w.site = SitePicker::new(site_names, h.site.as_deref());
+        w.two_factor = h.requires_2fa;
         w.extra = TextField::with(h.extra_args.clone().unwrap_or_default());
         w.extra_identities = h.identity_files.iter().skip(1).cloned().collect();
         // secret stays blank on edit (blank = keep existing)
@@ -299,6 +305,7 @@ impl Wizard {
             jump: TextField::new(),
             tags: TextField::new(),
             site: SitePicker::new(site_names, None),
+            two_factor: false,
             extra: TextField::new(),
             browser: None,
             error: None,
@@ -326,7 +333,13 @@ impl Wizard {
             AuthMethod::Password => v.push(Field::Secret),
             AuthMethod::Agent => {}
         }
-        v.extend([Field::JumpHosts, Field::Tags, Field::Site, Field::ExtraArgs]);
+        v.extend([
+            Field::JumpHosts,
+            Field::Tags,
+            Field::Site,
+            Field::TwoFactor,
+            Field::ExtraArgs,
+        ]);
         v
     }
 
@@ -340,7 +353,7 @@ impl Wizard {
             Field::JumpHosts => Some(&mut self.jump),
             Field::Tags => Some(&mut self.tags),
             Field::ExtraArgs => Some(&mut self.extra),
-            Field::Auth | Field::Identity | Field::Site => None,
+            Field::Auth | Field::Identity | Field::Site | Field::TwoFactor => None,
         }
     }
 
@@ -354,7 +367,7 @@ impl Wizard {
             Field::JumpHosts => Some(&self.jump),
             Field::Tags => Some(&self.tags),
             Field::ExtraArgs => Some(&self.extra),
-            Field::Auth | Field::Identity | Field::Site => None,
+            Field::Auth | Field::Identity | Field::Site | Field::TwoFactor => None,
         }
     }
 
@@ -407,6 +420,12 @@ impl Wizard {
                 Field::Site => match code {
                     KeyCode::Left => self.site.prev(),
                     KeyCode::Right | KeyCode::Char(' ') => self.site.next(),
+                    _ => {}
+                },
+                Field::TwoFactor => match code {
+                    KeyCode::Left | KeyCode::Right | KeyCode::Char(' ') => {
+                        self.two_factor = !self.two_factor
+                    }
                     _ => {}
                 },
                 f => {
@@ -487,6 +506,7 @@ impl Wizard {
         h.jump_hosts = split_list(&self.jump.value);
         h.tags = split_tags(&self.tags.value);
         h.site = self.site.selected().map(str::to_string);
+        h.requires_2fa = self.two_factor;
         let extra = self.extra.value.trim();
         h.extra_args = (!extra.is_empty()).then(|| extra.to_string());
 
@@ -697,6 +717,13 @@ fn field_value(w: &Wizard, field: Field) -> (String, bool) {
         ),
         Field::Identity => (w.identity.display(), w.identity.selected().is_none()),
         Field::Site => (w.site.display(), w.site.selected().is_none()),
+        Field::TwoFactor => (
+            format!(
+                "< {} >    (no · yes)",
+                if w.two_factor { "yes" } else { "no" }
+            ),
+            false,
+        ),
         Field::Secret => {
             let n = w.secret.value.chars().count();
             if n == 0 {
@@ -840,6 +867,28 @@ mod tests {
             WizardOutcome::Save { host, .. } => assert_eq!(host.site.as_deref(), Some("prod-dc")),
             _ => panic!("expected save"),
         }
+    }
+
+    #[test]
+    fn two_factor_chooser_toggles_and_saves() {
+        let mut w = with_keys(&[]);
+        type_str(&mut w, "n");
+        goto(&mut w, Field::Hostname);
+        type_str(&mut w, "h");
+        goto(&mut w, Field::TwoFactor);
+        w.handle_key(k(KeyCode::Right)); // no -> yes
+        match w.try_save() {
+            WizardOutcome::Save { host, .. } => assert!(host.requires_2fa),
+            _ => panic!("expected save"),
+        }
+    }
+
+    #[test]
+    fn from_host_reflects_requires_2fa() {
+        let mut h = Host::new("a", "h");
+        h.requires_2fa = true;
+        let w = Wizard::from_host(&h, &[]);
+        assert!(w.two_factor);
     }
 
     #[test]


### PR DESCRIPTION
Flag a host as requiring an interactive verification code (add/edit form, or `sshelf add --2fa`). Connecting to it now shows a popup to enter the current code before the exec() handoff; the code is supplied to ssh's keyboard-interactive prompt through the same SSH_ASKPASS helper that supplies a stored password.

This fixes connects that previously failed: a host with a stored secret runs ssh with SSH_ASKPASS_REQUIRE=force, which routes the verification prompt to our helper with no terminal fallback (confirmed by a spike), so the helper declined it and auth failed. The helper now answers a non-secret prompt with the queued code (read from SSHELF_2FA_CODE); a password or passphrase prompt still takes the stored secret, so the code is never sent to a password prompt. configure_askpass force-wires the helper when a secret exists OR a code is queued, so key+2FA hosts work too. The CLI direct-connect path (no TUI) prompts for the code on the terminal.

Manual entry only — no TOTP seeds are stored (rejected: same-vault second factor + a new dep). New module ui/two_factor.rs; Host.requires_2fa (old files load false); exec_connect/configure_askpass take an optional code (transfer + forward spawners pass None). Docs updated (decisions D-022, data-model, ux, structure, README, CHANGELOG).