### PR TITLE
Package for crates.io and RedHat/Fedora (.rpm)

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -1,0 +1,41 @@
+# Publishes the crate to crates.io after a successful, tag-triggered Release.
+#
+# cargo-dist has no built-in crates.io publisher, so — like the .deb/.rpm companions — this runs
+# via workflow_run (only when dist's "Release" build succeeds) and publishes independently:
+# `cargo publish` builds + uploads the crate source from the tag, so it needs none of the release
+# binaries. Needs a CARGO_REGISTRY_TOKEN repo secret; without it the publish is skipped (so the
+# workflow stays green until you add the token).
+name: release-crates
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: cargo publish (crates.io)
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }} # the release tag
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "CARGO_REGISTRY_TOKEN not set — skipping crates.io publish." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          cargo publish --locked

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -1,0 +1,74 @@
+# Builds RedHat/Fedora .rpm packages (x86_64 + aarch64) and attaches them to the GitHub Release.
+#
+# The .rpm ships a **static musl** binary so it runs on any RPM distro regardless of glibc
+# (Fedora, RHEL/Rocky/Alma, openSUSE) — sshelf only shells out to the system ssh/sftp, so nothing
+# is distro-specific. Like release-deb, this runs *after* dist's "Release" via workflow_run and
+# only attaches assets (dist owns release creation).
+name: release-rpm
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: write # to attach assets to the Release
+
+jobs:
+  rpm:
+    name: .rpm (${{ matrix.arch }})
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x86_64, os: ubuntu-22.04, target: x86_64-unknown-linux-musl }
+          - { arch: aarch64, os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl } # native arm64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }} # the release tag
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install musl toolchain + cargo-generate-rpm
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          cargo install cargo-generate-rpm --locked
+
+      - name: Build (static musl)
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Generate completions + man page
+        run: |
+          set -euo pipefail
+          bin=target/${{ matrix.target }}/release/sshelf
+          mkdir -p dist-extra
+          "$bin" completions bash > dist-extra/sshelf.bash
+          "$bin" completions zsh  > dist-extra/_sshelf
+          "$bin" completions fish > dist-extra/sshelf.fish
+          "$bin" man              > dist-extra/sshelf.1
+
+      # generate-rpm rewrites the `target/release` asset paths to the per-target dir via --target.
+      - name: Build .rpm
+        run: cargo generate-rpm --target ${{ matrix.target }}
+
+      - name: Locate the .rpm
+        id: rpm
+        run: |
+          set -euo pipefail
+          path=$(find target -name '*.rpm' -print -quit)
+          test -n "$path" || { echo "no .rpm produced"; exit 1; }
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+
+      - name: Attach to the Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.workflow_run.head_branch }}
+          files: ${{ steps.rpm.outputs.path }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ versions follow SemVer.
 
 ## [Unreleased]
 
+### Added
+- **Install from [crates.io](https://crates.io/crates/sshelf)** — `cargo install sshelf` (published
+  automatically on each release).
+- **RedHat/Fedora `.rpm` packages** (x86_64 + aarch64) attached to every release, built as a static
+  musl binary so they run on any RPM distro (Fedora, RHEL/Rocky/Alma, openSUSE) regardless of glibc.
+
 ## [0.8.0] — 2026-06-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,15 @@ name = "sshelf"
 version = "0.8.0"
 edition = "2024"
 rust-version = "1.88"
-description = "A TUI for managing and connecting to SSH hosts — generates the ssh command, never touches ~/.ssh/config."
+description = "Fast terminal UI for your SSH hosts: fuzzy-search and connect, transfer files over SFTP, and run background port forwards — keeps its own host database and never edits ~/.ssh/config."
 license = "MIT OR Apache-2.0"
-keywords = ["ssh", "tui", "terminal", "fuzzy", "ratatui"]
+readme = "README.md"
+keywords = ["ssh", "tui", "ssh-client", "sftp", "terminal"]
 categories = ["command-line-utilities"]
 repository = "https://github.com/max-rh/sshelf"
-homepage = "https://github.com/max-rh/sshelf"
+homepage = "https://max-rh.github.io/sshelf"
+# Keep the published crate lean: build/docs/CI infrastructure isn't needed to `cargo install`.
+exclude = [".github/", "docs/", "examples/", "book.toml", "dist-workspace.toml"]
 
 [dependencies]
 age = "0.10"
@@ -71,3 +74,27 @@ assets = [
     ["dist-extra/sshelf.fish", "usr/share/fish/vendor_completions.d/sshelf.fish", "644"],
     ["dist-extra/sshelf.1", "usr/share/man/man1/sshelf.1", "644"],
 ]
+
+# RedHat/Fedora .rpm metadata (used by `cargo generate-rpm`). The .rpm is built as a **static
+# musl** binary in .github/workflows/release-rpm.yml so it runs on any RPM distro regardless of
+# glibc; `cargo generate-rpm --target <triple>` rewrites the `target/release` asset paths below to
+# the per-target dir. Completions + man page are generated in CI, same as the .deb.
+[package.metadata.generate-rpm]
+# A static binary has no shared-library deps; don't let auto-req add bogus glibc `Requires`.
+auto-req = "no"
+summary = "Fast terminal UI for managing and connecting to SSH hosts"
+assets = [
+    { source = "target/release/sshelf", dest = "/usr/bin/sshelf", mode = "0755" },
+    { source = "README.md", dest = "/usr/share/doc/sshelf/README.md", mode = "0644", doc = true },
+    { source = "SECURITY.md", dest = "/usr/share/doc/sshelf/SECURITY.md", mode = "0644", doc = true },
+    { source = "LICENSE-MIT", dest = "/usr/share/licenses/sshelf/LICENSE-MIT", mode = "0644", doc = true },
+    { source = "LICENSE-APACHE", dest = "/usr/share/licenses/sshelf/LICENSE-APACHE", mode = "0644", doc = true },
+    { source = "dist-extra/sshelf.bash", dest = "/usr/share/bash-completion/completions/sshelf", mode = "0644" },
+    { source = "dist-extra/_sshelf", dest = "/usr/share/zsh/site-functions/_sshelf", mode = "0644" },
+    { source = "dist-extra/sshelf.fish", dest = "/usr/share/fish/vendor_completions.d/sshelf.fish", mode = "0644" },
+    { source = "dist-extra/sshelf.1", dest = "/usr/share/man/man1/sshelf.1", mode = "0644" },
+]
+
+# We exec ssh; everything else (Secret Service, age vault) is bundled or optional.
+[package.metadata.generate-rpm.requires]
+openssh-clients = "*"

--- a/README.md
+++ b/README.md
@@ -71,10 +71,17 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/max-rh/sshelf/releases/
 sudo apt install ./sshelf_*_amd64.deb      # or *_arm64.deb
 ```
 
-**From source** (needs **Rust 1.88+**):
+**Fedora / RHEL / Rocky / openSUSE** — grab the `.rpm` for your architecture from the
+[latest release](https://github.com/max-rh/sshelf/releases/latest), then:
 
 ```sh
-cargo install --git https://github.com/max-rh/sshelf
+sudo dnf install ./sshelf-*.x86_64.rpm     # or .aarch64.rpm
+```
+
+**Cargo** (from [crates.io](https://crates.io/crates/sshelf); needs **Rust 1.88+**):
+
+```sh
+cargo install sshelf
 ```
 
 > Linux uses a pure-Rust Secret Service backend (no `libdbus`/OpenSSL build deps).

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,16 +1,21 @@
 # Packaging & distribution
 
-How `sshelf` ships to **Homebrew** (macOS + Linux) and **Debian/Ubuntu** (`.deb` / apt), for
-**x86_64 *and* arm64** on both OSes. Releases are driven from GitHub Actions on a `vX.Y.Z` tag.
+How `sshelf` ships to **Homebrew** (macOS + Linux), **Debian/Ubuntu** (`.deb`), **RedHat/Fedora**
+(`.rpm`), and **crates.io**, for **x86_64 *and* arm64**. Releases are driven from GitHub Actions on
+a `vX.Y.Z` tag.
 
 **Chosen stack:**
 - **[`dist`](https://opensource.axo.dev/cargo-dist/) (cargo-dist)** builds the binaries for all
   targets, makes the GitHub Release (tarballs + checksums), generates the **Homebrew formula**
   and pushes it to your tap, and emits a curl-able shell installer.
-- A hand-written **`.deb` companion workflow** (`.github/workflows/release-deb.yml`) builds the
-  Debian/Ubuntu packages dist doesn't, and attaches them to the same Release.
+- Hand-written **companion workflows** attach what dist doesn't build to the same Release, each
+  triggered via `workflow_run` *after* dist's "Release" completes (so they never race to create
+  it): `release-deb.yml` (`.deb`, via `cargo deb`), `release-rpm.yml` (`.rpm`, via
+  `cargo generate-rpm`, built as a **static musl** binary), and `release-crates.yml`
+  (`cargo publish` to crates.io).
 - **clap** generates shell completions + a man page (via `sshelf completions` / `sshelf man`).
-- **No crates.io** (by choice).
+- **crates.io:** cargo-dist has no built-in crates.io publish job, so `release-crates.yml` runs
+  `cargo publish` (needs a `CARGO_REGISTRY_TOKEN` repo secret; skips cleanly if it's unset).
 
 GitHub user is **`max-rh`**; the repo is `github.com/max-rh/sshelf`; the Homebrew tap is
 `max-rh/homebrew-tap`.
@@ -36,8 +41,9 @@ Set in `Cargo.toml` before the first release:
 [package]
 # ...existing fields...
 repository = "https://github.com/max-rh/sshelf"
-homepage   = "https://github.com/max-rh/sshelf"
+homepage   = "https://max-rh.github.io/sshelf"   # the GitHub Pages docs site
 readme     = "README.md"
+# `exclude` keeps the published crate lean (drops docs/, .github/, examples/, the gif, etc.).
 # `authors` is optional (cargo no longer auto-fills it) — omit it, or use a project ALIAS,
 # never your personal email: this file is public on GitHub and copied into every .deb.
 ```
@@ -69,7 +75,7 @@ Conventions / facts that matter:
 | macOS Intel | `x86_64-apple-darwin` | dist (cross on the arm64 runner) |
 | Linux x86_64 (Debian/Ubuntu amd64) | `x86_64-unknown-linux-gnu` | dist + `.deb` on `ubuntu-22.04` |
 | Linux arm64 (Debian/Ubuntu arm64) | `aarch64-unknown-linux-gnu` | dist + `.deb` on `ubuntu-24.04-arm` |
-| Linux x86_64/arm64 static (portable tarball) | `*-unknown-linux-musl` | optional in dist |
+| Linux x86_64/arm64 static (the `.rpm`) | `*-unknown-linux-musl` | `release-rpm.yml` (`cargo generate-rpm`) |
 
 - **GitHub's free arm64 Linux runners** (`ubuntu-24.04-arm`, GA for *public* repos since Aug
   2025) build arm64 **natively** — no QEMU. (They aren't available to private repos on the free tier.)
@@ -225,6 +231,51 @@ most users.
 
 ---
 
+## 4b. RedHat/Fedora `.rpm` (static musl)
+
+Same shape as the `.deb`, with two differences. The package metadata is in `Cargo.toml`
+(`[package.metadata.generate-rpm]`, built by [`cargo-generate-rpm`](https://github.com/cat-in-136/cargo-generate-rpm)),
+and the binary is built **static musl** (`*-unknown-linux-musl`) so one `.rpm` runs on any RPM
+distro — Fedora, RHEL/Rocky/Alma, openSUSE — **regardless of glibc version**. (sshelf is
+distro-agnostic at runtime: it only shells out to the system `ssh`/`sftp`/`ps`/`kill`, all OpenSSH/
+procps, and the Linux keyring is the pure-Rust Secret Service with the `age`-vault fallback — none
+of it is Debian- or RPM-specific.) `auto-req = "no"` stops rpm from adding bogus shared-lib
+`Requires` to a static binary; we declare `openssh-clients` explicitly.
+
+[`.github/workflows/release-rpm.yml`](../.github/workflows/release-rpm.yml) mirrors the `.deb`
+workflow: `workflow_run` after dist's Release, a matrix of `x86_64` (`ubuntu-22.04`) and `aarch64`
+(`ubuntu-24.04-arm`, native), `rustup target add <musl>`, `cargo build --target <musl>`, generate
+completions/man, then `cargo generate-rpm --target <musl>` (which rewrites the `target/release`
+asset paths to the per-target dir) and attaches the `.rpm`. Users install with:
+
+```sh
+sudo dnf install ./sshelf-0.8.0-1.x86_64.rpm     # or .aarch64.rpm
+```
+
+> **Why musl, not glibc like the `.deb`:** a glibc binary built on the CI runner only runs on
+> distros with an equal-or-newer glibc, which excludes older RHEL. Static musl sidesteps that
+> entirely. (The `.deb` keeps glibc since Debian/Ubuntu users build/run on a known-recent glibc.)
+
+---
+
+## 4c. crates.io (`cargo install sshelf`)
+
+cargo-dist has **no built-in crates.io publish job** (`publish-jobs` only knows `homebrew`/`npm`/
+custom `./jobs`), so publishing is a separate companion workflow,
+[`release-crates.yml`](../.github/workflows/release-crates.yml): `workflow_run` after the Release,
+then `cargo publish --locked`. It needs a **`CARGO_REGISTRY_TOKEN`** repo secret (a crates.io API
+token, ideally scoped to the `sshelf` crate); the step skips cleanly if the secret is unset, so the
+workflow stays green before it's added. The crate's `Cargo.toml` carries the required metadata
+(`description`, `license`, `keywords`, `categories`, `repository`, `homepage`) and an `exclude`
+that drops `docs/`/`.github/`/`examples/` from the published tarball. `cargo publish` builds from
+the tag's source, so it's independent of the release binaries.
+
+```sh
+cargo install sshelf      # once published
+```
+
+---
+
 ## 5. Shell completions & man page
 
 `sshelf` generates these itself (clap), so packaging needs no extra tooling:
@@ -351,6 +402,8 @@ is fine for Homebrew; ship a stapled `.pkg` for offline direct downloads.)
    real-TTY acceptance check in `docs/progress.md`):
    - `brew install max-rh/tap/sshelf`
    - `sudo apt install ./sshelf_*_amd64.deb`
+   - `sudo dnf install ./sshelf-*.x86_64.rpm`
+   - `cargo install sshelf` (after the crates.io publish lands)
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -3,8 +3,23 @@
 Reverse-chronological. Newest entry on top. Every change to the project adds an entry here
 (the docs-in-sync rule). Keep entries short: what changed, why, and what's next.
 
-**Current milestone:** Interactive 2FA — prompt for a verification code on connect and inject it
-via the askpass helper, targeting **v0.8.0**. (Port forwarding shipped in v0.7.0.)
+**Current milestone:** Distribution — publish to crates.io and ship `.rpm` packages, plus a leaner
+published crate. (Interactive 2FA shipped in v0.8.0.)
+
+---
+
+## 2026-06-23 — Distribution: crates.io + RPM packaging
+
+- **crates.io:** new `release-crates.yml` (workflow_run after dist's Release → `cargo publish`;
+  needs a `CARGO_REGISTRY_TOKEN` secret, skips cleanly if unset). cargo-dist has no built-in
+  crates.io publish job — `publish-jobs` only knows `homebrew`/`npm`/custom — so it's a companion
+  workflow like the `.deb`.
+- **`.rpm`:** new `release-rpm.yml` + `[package.metadata.generate-rpm]` (x86_64 + aarch64), built
+  as a **static musl** binary so one rpm runs on any RPM distro regardless of glibc. ssh works
+  identically on RHEL/Fedora — sshelf only shells out to system ssh/sftp/ps/kill.
+- `Cargo.toml`: homepage → the Pages docs site, refreshed description + keywords, `readme`, and an
+  `exclude` that trims the published crate 64 → 43 files (drops docs/, .github/, examples/, the
+  gif). Docs synced (packaging.md §4b/§4c, README install, CHANGELOG). Ships in the next release.
 
 ---
 


### PR DESCRIPTION
Add two release companion workflows (triggered via workflow_run after dist's Release, like the existing .deb):
- release-crates.yml: `cargo publish` to crates.io. cargo-dist has no built-in crates.io publisher (publish-jobs only knows homebrew/npm/ custom), so it's a separate workflow; it needs a CARGO_REGISTRY_TOKEN secret and skips cleanly when that's unset.
- release-rpm.yml: .rpm for x86_64 + aarch64, built as a static musl binary so one package runs on any RPM distro (Fedora, RHEL/Rocky/Alma, openSUSE) regardless of glibc. sshelf only shells out to system ssh/sftp/ps/kill, so nothing is distro-specific.

Cargo.toml: point homepage at the Pages docs site, refresh the description and keywords, set readme, add [package.metadata.generate-rpm] (auto-req=no so a static binary gets no bogus libc Requires; openssh-clients), and an exclude that trims the published crate (docs/, .github/, examples/, the gif) from 64 to 43 files. Docs synced (packaging.md, README install, CHANGELOG, progress).