### PR TITLE
docs: split the user guide from internals; slim the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ versions follow SemVer.
 
 ## [Unreleased]
 
+### Changed
+- Docs: [the site](https://max-rh.github.io/sshelf/) now opens with a full user guide —
+  install, quickstart, per-feature pages, CLI reference, configuration, FAQ — and the README
+  is a shorter landing page that links into it. No behavior changes.
+
 ## [0.9.0] — 2026-06-23
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,10 @@ same change, and add a dated entry to `docs/progress.md`.**
 - Touched `ssh.rs`/argv logic → update `docs/ssh-command.md`.
 - Changed the data schema or file locations → update `docs/data-model.md`.
 - Added/moved a module → update `docs/structure.md`.
-- Changed a keybinding/screen/wizard step → update `docs/ux.md`.
+- Changed user-facing behavior (a keybinding, screen, CLI command, config key) → update the
+  relevant **Guide** page under `docs/` (install, quickstart, hosts, search-connect, transfer,
+  port-forwarding, sites-tags, passwords-2fa, import, cli, configuration, faq); UI design
+  rationale lives in `docs/ux.md`.
 - Made a non-trivial design choice → add an entry to `docs/decisions.md`.
 - Anything security-relevant (secrets, askpass, perms) → update `docs/security.md`.
 - **Always** append what you did + what's next to `docs/progress.md`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # sshelf
 
+[![crates.io](https://img.shields.io/crates/v/sshelf.svg)](https://crates.io/crates/sshelf)
+[![CI](https://github.com/max-rh/sshelf/actions/workflows/ci.yml/badge.svg)](https://github.com/max-rh/sshelf/actions/workflows/ci.yml)
+[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
+
 A fast terminal UI for managing and connecting to SSH hosts. Save each node once, then
 fuzzy-search and connect in two keystrokes.
 
@@ -23,34 +27,28 @@ for the right `ssh -i … -J … user@host` invocation.
 
 ## Why sshelf
 
-Most SSH managers read or rewrite `~/.ssh/config`. `sshelf` deliberately doesn't: it maintains
-an independent database, so it never risks corrupting a config shared with Ansible/Terraform/
-your editor, and adds things plain SSH config can't express as nicely:
+Most SSH managers read or rewrite `~/.ssh/config`. `sshelf` deliberately doesn't: it keeps an
+independent database, so it never risks corrupting a config shared with Ansible/Terraform/your
+editor — and it adds what plain SSH config can't express:
 
-- **Atuin-style fuzzy launcher** — type to filter, `Enter` to connect.
-- **Dual-pane file transfer** (`Ctrl-t`) — a two-pane browser to copy files and folders to and
-  from a host over SFTP/SCP, with fuzzy search on both sides and live progress. It authenticates
-  once (reusing the host's keys/agent or stored password) and never touches `~/.ssh/config`.
-- **Background port forwarding** (`Ctrl-f`) — start a Local (`-L`), Remote (`-R`) or Dynamic
-  (`-D` SOCKS) SSH tunnel that **keeps running after you quit sshelf**. A manager screen (`F4`)
-  lists every active forward and stops any; they're reconciled against the OS on each launch.
-- **Guided add/edit form** — hostname, user, port, auth, jump hosts, tags, site, 2FA, extra args.
-- **Sites** (`F3`) — group hosts (one per host, e.g. a data center) and optionally give the site
-  a **shared bastion + default user/port/key** that members inherit at connect time. The list
-  groups by site; `site:NAME` filters. Distinct from the many-valued, free-form tags.
-- **Auto-supplied passwords** for password-auth hosts (via `SSH_ASKPASS`; no `sshpass`, the
-  secret never appears in `ps`). Stored in your OS keyring, or an encrypted vault.
-- **2FA hosts** — flag a host that wants an interactive verification code (TOTP /
-  keyboard-interactive) and sshelf prompts for it on connect, feeding it through the same askpass
-  channel (manual entry; no stored TOTP seeds).
-- **Jump hosts** (`ProxyJump`), **tags/groups** (`tag:prod`), and **frecency** ordering
-  (most-used-recently float to the top).
-- **Read-only import** from `~/.ssh/config` to get started.
+- **Fuzzy launcher** — type to filter, `Enter` to connect; your most-used hosts float to the top.
+- **Dual-pane file transfer** (`Ctrl-t`) — copy files and folders both ways over SFTP, with
+  fuzzy search on both sides and one authentication.
+- **Background port forwarding** (`Ctrl-f`) — Local / Remote / SOCKS tunnels that keep running
+  after you quit; `F4` lists and stops them.
+- **Sites & tags** (`F3`) — group hosts; a site can carry a shared bastion + defaults that
+  members inherit at connect time.
+- **Auto-supplied passwords** — stored in your OS keyring (or an encrypted vault), fed to `ssh`
+  via `SSH_ASKPASS`: never in a file, never visible in `ps`.
+- **2FA hosts** — flag a host and sshelf prompts for the verification code on connect.
+- **Jump hosts, a guided add/edit form, frecency ordering, read-only import** from `~/.ssh/config`.
+
+**Never:** no telemetry, no account, no cloud — and it will never edit your SSH config.
 
 ## Install
 
-macOS and Linux, on x86_64 and arm64. The prebuilt installs below need **no Rust toolchain**;
-at runtime sshelf wants **OpenSSH 8.4+** (for password auto-supply).
+macOS and Linux, x86_64 and arm64 — no Rust toolchain needed for the prebuilt packages. At
+runtime sshelf wants **OpenSSH 8.4+** (for password auto-supply).
 
 **Homebrew** (macOS or Linux):
 
@@ -64,151 +62,66 @@ brew install max-rh/tap/sshelf
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/max-rh/sshelf/releases/latest/download/sshelf-installer.sh | sh
 ```
 
-**Debian/Ubuntu** — grab the `.deb` for your architecture from the
-[latest release](https://github.com/max-rh/sshelf/releases/latest), then:
+<details>
+<summary><b>More options</b> — Debian/Ubuntu · Fedora/RHEL · Gentoo · cargo</summary>
+
+**Debian/Ubuntu** — grab the `.deb` from the
+[latest release](https://github.com/max-rh/sshelf/releases/latest), then
+`sudo apt install ./sshelf_*_amd64.deb` (or `*_arm64.deb`).
+
+**Fedora / RHEL / Rocky / openSUSE** — grab the `.rpm` (static build, works on any RPM
+distro) from the [latest release](https://github.com/max-rh/sshelf/releases/latest), then
+`sudo dnf install ./sshelf-*.x86_64.rpm` (or `.aarch64.rpm`).
+
+**Gentoo** — community-maintained overlay (unofficial; thanks to @masterwolf-git):
+`eselect repository enable masterwolf && emerge --sync && emerge --ask app-admin/sshelf`.
+
+**Cargo** (from [crates.io](https://crates.io/crates/sshelf); needs Rust 1.88+):
+`cargo install sshelf`.
+
+Shell tab-completion ships with every package — open a new shell after installing. On Linux,
+secrets use a pure-Rust Secret Service backend (no `libdbus`/OpenSSL build deps).
+
+</details>
+
+Full details + completions setup: **[Install guide](https://max-rh.github.io/sshelf/install.html)**.
+
+## First five minutes
 
 ```sh
-sudo apt install ./sshelf_*_amd64.deb      # or *_arm64.deb
-```
-**Gentoo** — via the community-maintained Masterwolf overlay
-(unofficial; thanks to @masterwolf-git):
-
-add Masterwolf repository `eselect repository enable masterwolf`, then:
-
-```sh
-emerge --sync   # if needed
-emerge --ask app-admin/sshelf
+sshelf                        # launch the TUI — Ctrl-a adds your first host
+sshelf import --dry-run       # preview a read-only import from ~/.ssh/config
+sshelf import                 # …do it
+sshelf prod-web               # connect straight to a saved host (skips the TUI)
+sshelf -                      # reconnect to the most recently used host
+sshelf list tag:prod --json   # scriptable listing (fields + generated command)
+sshelf print-command db       # print the ssh command instead of running it
 ```
 
-**Fedora / RHEL / Rocky / openSUSE** — grab the `.rpm` for your architecture from the
-[latest release](https://github.com/max-rh/sshelf/releases/latest), then:
+In the TUI: type to filter (plus `tag:NAME` / `site:NAME`), `Enter` to connect — **`F1` shows
+every key**. On connect sshelf hands the terminal to `ssh` (it `exec`s into it); when the
+session ends you're back at your shell.
 
-```sh
-sudo dnf install ./sshelf-*.x86_64.rpm     # or .aarch64.rpm
-```
+## Documentation
 
-**Cargo** (from [crates.io](https://crates.io/crates/sshelf); needs **Rust 1.88+**):
-
-```sh
-cargo install sshelf
-```
-
-> Linux uses a pure-Rust Secret Service backend (no `libdbus`/OpenSSL build deps).
-
-> Shell tab-completion (subcommands + flags) ships with every package. After installing, **open a
-> new shell** (or `exec $SHELL`) so it loads. For completion of your saved **host names**, see
-> [Shell completions](#shell-completions) below.
-
-## Usage
-
-```sh
-sshelf                       # launch the TUI
-sshelf <host>                # connect straight to a saved host by name (skips the TUI)
-sshelf -                     # reconnect to the most recently used host
-sshelf add                   # open the TUI add form
-sshelf add <name> -H <host>  # add a host non-interactively (see "Adding hosts from the CLI")
-sshelf print-command <host>  # print the generated ssh command without connecting
-sshelf list                  # print saved hosts (with a ·site· column)
-sshelf list <query>          # filter: fuzzy text and/or tag:NAME / site:NAME (e.g. site:prod-dc)
-sshelf list --json [query]   # machine-readable output (host fields + the generated command)
-sshelf sites                 # list sites (member counts + shared defaults)
-sshelf sites add <name> -u deploy -J bastion   # define a site with shared defaults
-sshelf --config FILE         # use a specific config file (also: $SSHELF_CONFIG)
-sshelf --transfer-log FILE   # log transfer ssh/sftp commands + errors to FILE (debugging)
-sshelf import [--dry-run]    # read-only import from ~/.ssh/config
-echo "$PASS" | sshelf set-password <name>   # store a password (scriptable / headless)
-```
-
-**Keys:** type to filter · `tag:NAME` / `site:NAME` to filter · `↑/↓` move · `Enter` connect ·
-`Ctrl-a` add · `Ctrl-e` edit · `Ctrl-d` delete · `Ctrl-y` yank the `ssh` command · `Ctrl-t`
-transfer files · `Ctrl-f` port-forward · `Ctrl-o` import · `F1` help · `F2` settings · `F3` sites ·
-`F4` forwards · `Esc`/`Ctrl-c` quit.
-
-In the **add/edit** form the Key field picks an identity: `←/→` cycles keys found in `~/.ssh`
-(including `.pem`), and `Enter` opens a file browser (type to fuzzy-filter) to choose a key
-anywhere. **F2** opens settings (config & hosts-file locations).
-
-On connect, `sshelf` hands the terminal to `ssh` (it `exec`s into it); when the session ends
-you're back at your shell.
-
-## Adding hosts from the CLI
-
-`sshelf add` with no arguments opens the TUI form. With any argument it adds a host
-non-interactively (handy for scripts and dotfiles); `NAME` and `--hostname` are required:
-
-```sh
-# key auth (a -i identity implies --auth key)
-sshelf add prod-web -H 10.25.25.10 -u deploy -i ~/.ssh/id_ed25519 -t prod,web
-
-# jump host + custom port
-sshelf add prod-db -H 10.25.25.25 -u mike -p 5432 -J bastion.example.net -i ~/.ssh/db
-
-# agent auth (the default) with extra raw ssh flags
-sshelf add edge -H edge.example.net --extra "-o ServerAliveInterval=30"
-
-# password auth — pipe the secret in (kept out of argv/history; stored in the keyring or vault)
-echo "$PASS" | sshelf add legacy -H 10.0.0.9 -u root --password-stdin
-```
-
-| Flag | Meaning |
-|---|---|
-| `NAME` (positional) | Alias to search/connect by. **Required.** |
-| `-H, --hostname <HOST>` | IP or DNS name. **Required.** |
-| `-u, --user <USER>` | Login user (defaults to `$USER` at connect time). |
-| `-p, --port <PORT>` | SSH port (default 22). |
-| `-a, --auth <agent\|key\|password>` | Auth method. Inferred as `key` with `--identity`, `password` with `--password-stdin`, else `agent`. |
-| `-i, --identity <PATH>` | Identity file for key auth (repeatable). |
-| `-J, --jump <HOST>` | ProxyJump host (repeatable or comma-separated). Key/agent auth only. |
-| `-t, --tag <TAG>` | Tag (repeatable or comma-separated). |
-| `--extra "<ARGS>"` | Extra raw ssh flags, appended verbatim. |
-| `--password-stdin` | Read a password / key passphrase from stdin and store it. |
-
-A duplicate name is refused. To store a secret after the fact instead of `--password-stdin`,
-use `sshelf set-password <name>`.
-
-## Shell completions
-
-The packages install static completion (subcommands + flags), also printed by
-`sshelf completions <shell>`. For **host-name** completion — `sshelf <Tab>` completing your saved
-hosts — enable dynamic completions:
-
-```sh
-source <(COMPLETE=bash sshelf)   # bash — add to ~/.bashrc
-source <(COMPLETE=zsh sshelf)    # zsh  — add to ~/.zshrc (after compinit)
-COMPLETE=fish sshelf | source    # fish — add to ~/.config/fish/config.fish
-```
-
-After that, `sshelf prod<Tab>` completes your `prod-*` hosts; the same works after
-`sshelf print-command` and `sshelf set-password`.
-
-## Configuration
-
-`~/.config/sshelf/config.toml` (written with comments on first run):
-
-| Key | Default | Meaning |
-|---|---|---|
-| `decay_rate` | `0.2` | Frecency decay per day (higher = recency matters more). |
-| `default_sort` | `"frecency"` | Idle list order: `"frecency"` or `"name"`. |
-| `accent` | `"cyan"` | UI accent color. |
-| `hosts_file` | (config dir) | Custom host-database path. Editable via **F2** settings; `~` is expanded. |
-
-Point sshelf at an alternate config with `--config FILE` or `$SSHELF_CONFIG` (the config-file
-location itself isn't stored in the config — that'd be circular). The hosts-file location *is*
-a setting, editable from the **F2** settings screen.
-
-Data lives under XDG dirs: hosts in `~/.config/sshelf/hosts.toml` (human-readable),
-usage state in `~/.local/share/sshelf/`.
+The **[user guide](https://max-rh.github.io/sshelf/)** covers everything:
+[Quickstart](https://max-rh.github.io/sshelf/quickstart.html) ·
+[CLI reference](https://max-rh.github.io/sshelf/cli.html) ·
+[Configuration](https://max-rh.github.io/sshelf/configuration.html) ·
+[FAQ](https://max-rh.github.io/sshelf/faq.html) — plus per-feature pages for
+[file transfer](https://max-rh.github.io/sshelf/transfer.html),
+[port forwarding](https://max-rh.github.io/sshelf/port-forwarding.html),
+[sites & tags](https://max-rh.github.io/sshelf/sites-tags.html), and
+[passwords & 2FA](https://max-rh.github.io/sshelf/passwords-2fa.html).
+Architecture and design decisions live in [`docs/`](docs/index.md).
 
 ## Passwords & security
 
-Prefer SSH keys / agent where you can. For password-auth hosts, `sshelf` stores the secret in
-your **OS keyring** by default (macOS Keychain, Linux Secret Service). On headless systems with
-no keyring, set `SSHELF_VAULT_PASSPHRASE` to use an **age-encrypted vault** instead. Passwords
-are never written to `hosts.toml` and never passed on the command line.
-
-`sshelf` makes **no network calls of its own** — no telemetry, no account, no cloud. The only
-network activity is the `ssh` it hands your terminal to. See [`SECURITY.md`](SECURITY.md) for
-the full threat model.
+Prefer SSH keys / agent where you can. Stored secrets live in the macOS Keychain / Linux
+Secret Service (or an `age`-encrypted vault on headless systems) — never in `hosts.toml`,
+never on a command line. `sshelf` makes **no network calls of its own** — no telemetry, no
+account, no cloud; the only network activity is the `ssh` it hands your terminal to. See
+[`SECURITY.md`](SECURITY.md) for the full threat model.
 
 ## Support
 
@@ -222,7 +135,3 @@ If sshelf is useful to you, a Bitcoin tip is appreciated (entirely optional):
 
 Dual-licensed under either [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE), at your option —
 the Rust-ecosystem norm.
-
-## Documentation
-
-Architecture, data model, and design decisions live in [`docs/`](docs/index.md).

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,17 +2,32 @@
 
 [Introduction](index.md)
 
-# Using sshelf
+# Guide
 
-- [Screens, keys & theming](ux.md)
-- [The ssh command & askpass](ssh-command.md)
-- [Data model & files](data-model.md)
-- [Security](security.md)
+- [Install](install.md)
+- [Quickstart](quickstart.md)
+- [Adding & editing hosts](hosts.md)
+- [Searching & connecting](search-connect.md)
+- [Transferring files](transfer.md)
+- [Port forwarding](port-forwarding.md)
+- [Sites & tags](sites-tags.md)
+- [Passwords, keys & 2FA](passwords-2fa.md)
+- [Importing from ~/.ssh/config](import.md)
+- [CLI reference](cli.md)
+- [Configuration](configuration.md)
+- [FAQ & troubleshooting](faq.md)
+
+# Understanding sshelf
+
+- [Security & threat model](security.md)
+- [How the ssh command is built](ssh-command.md)
 
 # Development
 
 - [Architecture](architecture.md)
 - [Project structure](structure.md)
+- [Data model & files](data-model.md)
+- [UI design notes](ux.md)
 - [Decision log](decisions.md)
 - [Packaging & distribution](packaging.md)
 - [Progress log](progress.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,84 @@
+# CLI reference
+
+Everything sshelf does without opening the TUI.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `sshelf` | Launch the interactive TUI. |
+| `sshelf <host>` | Connect straight to a saved host by **name or id**, skipping the TUI — same connect path as `Enter` (frecency recorded, stored secret auto-supplied, [2FA code](passwords-2fa.md#two-factor-2fa-hosts) prompted on the terminal). A miss suggests the closest names; a host named like a subcommand (`list`, `import`, …) is reached via the TUI instead. |
+| `sshelf -` | Reconnect to the most recently used host. Errors (without connecting) if there's no history yet. |
+| `sshelf add [NAME …]` | Bare: open the TUI add form. With arguments: add a host non-interactively — see [below](#adding-hosts-from-the-cli). |
+| `sshelf list [query] [--json]` | List hosts (with a `·site·` column). `query` filters with the TUI's syntax — fuzzy text and/or `tag:NAME` / `site:NAME` (e.g. `sshelf list site:prod-dc`). |
+| `sshelf print-command <host>` | Print the generated, shell-quoted `ssh …` command (site defaults included) without connecting or touching frecency — the CLI twin of `Ctrl-y`. |
+| `sshelf sites [--json]` | List defined sites with member counts + their shared defaults. |
+| `sshelf sites add NAME [-u/-p/-J/-i]` | Define a [site](sites-tags.md) (settings optional; edit later with `F3`). |
+| `sshelf import [--dry-run]` | [Read-only import](import.md) from `~/.ssh/config`. |
+| `sshelf set-password <host>` | Store a password / key passphrase for a host, read from **stdin**. |
+| `sshelf completions <shell>` | Print static shell completions. |
+| `sshelf man` | Print the man page. |
+
+Global flags: **`--config FILE`** — use a specific config file (also `$SSHELF_CONFIG`); see
+[Configuration](configuration.md). **`--transfer-log FILE`** — append transfer diagnostics,
+no secrets, to FILE (also `$SSHELF_TRANSFER_LOG`); see
+[Transferring files](transfer.md#debugging-a-failing-transfer).
+
+## Adding hosts from the CLI
+
+`sshelf add` with arguments adds a host non-interactively (handy for scripts and dotfiles).
+`NAME` and `--hostname` are required:
+
+```sh
+# key auth (a -i identity implies --auth key)
+sshelf add prod-web -H 10.25.25.10 -u deploy -i ~/.ssh/id_ed25519 -t prod,web
+
+# jump host + custom port
+sshelf add prod-db -H 10.25.25.25 -u mike -p 5432 -J bastion.example.net -i ~/.ssh/db
+
+# agent auth (the default) with extra raw ssh flags
+sshelf add edge -H edge.example.net --extra "-o ServerAliveInterval=30"
+
+# password auth — pipe the secret in (kept out of argv/history; stored in the keyring or vault)
+echo "$PASS" | sshelf add legacy -H 10.0.0.9 -u root --password-stdin
+```
+
+| Flag | Meaning |
+|---|---|
+| `NAME` (positional) | Alias to search/connect by. **Required.** |
+| `-H, --hostname <HOST>` | IP or DNS name. **Required.** |
+| `-u, --user <USER>` | Login user (defaults to `$USER` at connect time). |
+| `-p, --port <PORT>` | SSH port (default 22). |
+| `-a, --auth <agent\|key\|password>` | Auth method. Inferred as `key` with `--identity`, `password` with `--password-stdin`, else `agent`. |
+| `-i, --identity <PATH>` | Identity file for key auth (repeatable). |
+| `-J, --jump <HOST>` | ProxyJump host (repeatable or comma-separated). Key/agent auth only. |
+| `-t, --tag <TAG>` | Tag (repeatable or comma-separated). |
+| `-s, --site <NAME>` | Assign the host to a [site](sites-tags.md). |
+| `--2fa` | Mark the host as needing a [verification code](passwords-2fa.md#two-factor-2fa-hosts) on connect. |
+| `--extra "<ARGS>"` | Extra raw ssh flags, appended verbatim. |
+| `--password-stdin` | Read a password / key passphrase from stdin and store it. |
+
+A duplicate name is refused. To store a secret after the fact, use
+`sshelf set-password <name>`.
+
+## Shell completions
+
+**Static** completion (subcommands + flags) ships with every package — open a new shell after
+installing so it loads. It's also printed by `sshelf completions <shell>`.
+
+**Dynamic** completion — `sshelf prod<Tab>` completing your saved **host names** — takes one
+line in your shell rc:
+
+```sh
+source <(COMPLETE=bash sshelf)   # bash — add to ~/.bashrc
+source <(COMPLETE=zsh sshelf)    # zsh  — add to ~/.zshrc (after compinit)
+COMPLETE=fish sshelf | source    # fish — add to ~/.config/fish/config.fish
+```
+
+Host-name completion works for direct connect, `print-command`, and `set-password`.
+
+## JSON output
+
+`sshelf list --json [query]` emits each selected host's fields **plus its generated `ssh`
+command**, and is always valid JSON even when the selection is empty — the stable surface for
+scripts and integrations. `sshelf sites --json` does the same for sites.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,43 @@
+# Configuration
+
+## `config.toml`
+
+Lives at `~/.config/sshelf/config.toml` (honors `XDG_CONFIG_HOME`) and is written with
+comments on first run:
+
+| Key | Default | Meaning |
+|---|---|---|
+| `decay_rate` | `0.2` | Frecency decay per day (higher = recency matters more). |
+| `default_sort` | `"frecency"` | Idle list order: `"frecency"` or `"name"`. |
+| `accent` | `"cyan"` | UI accent color: black / red / green / yellow / blue / magenta / cyan / white / gray. |
+| `hosts_file` | (config dir) | Custom host-database path; `~` is expanded. Editable from `F2`. |
+
+Point sshelf at an alternate **config file** with `--config FILE` or `$SSHELF_CONFIG` — the
+config-file location itself isn't a key in the file (that would be circular). The **hosts
+file** location *is* a setting.
+
+## The settings screen (`F2`)
+
+- **Config file** — shown read-only (it's chosen before the config is read; see above).
+- **Hosts file** — editable; blank means the default under the config dir. On save, an
+  *existing* file at the new path is **adopted** (loaded, never overwritten); a new path is
+  created from your current hosts, so they follow.
+
+## Where everything lives
+
+XDG paths on macOS **and** Linux (`~/.config` / `~/.local/share`, honoring
+`XDG_CONFIG_HOME` / `XDG_DATA_HOME`):
+
+| File | Default location | What it is |
+|---|---|---|
+| `hosts.toml` | `~/.config/sshelf/` | The host database — human-readable, hand-editable, nice to keep in dotfiles. |
+| `config.toml` | `~/.config/sshelf/` | The preferences above. |
+| `state.json` | `~/.local/share/sshelf/` | Frecency counters. App-managed; churns. |
+| `forwards.json` | `~/.local/share/sshelf/` | Ledger of active [port forwards](port-forwarding.md). App-managed. |
+| `vault.age` | `~/.local/share/sshelf/` | Encrypted secret store — only in [vault mode](passwords-2fa.md#where-secrets-live). |
+
+Secrets are **never** in `hosts.toml` — keyring or vault only. All writes are atomic
+(temp file + rename), so a crash mid-write can't corrupt your files.
+
+Hand-editing `hosts.toml` is supported — that's also how you give one host **multiple**
+identity files. The full schema: [Data model & files](data-model.md).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,77 @@
+# FAQ & troubleshooting
+
+## Why doesn't sshelf just use my SSH config?
+
+By design. `~/.ssh/config` is often shared, load-bearing infrastructure — Ansible, Terraform,
+your editor's remote mode all read it — and a tool that rewrites it can corrupt all of that.
+sshelf keeps an **independent database** and builds `ssh` commands from it with plain flags;
+its only contact with your SSH config is the explicit, [read-only import](import.md). (ssh
+itself still *reads* your config normally when sshelf launches it — sshelf just never writes
+it.)
+
+## What does sshelf need at runtime?
+
+**OpenSSH 8.4+** on your machine — password/passphrase auto-supply rides on
+`SSH_ASKPASS_REQUIRE`, added in OpenSSH 8.4 (2020). Check with `ssh -V`. Key/agent hosts work
+with anything reasonably modern. Platforms: macOS + Linux, x86_64 and arm64.
+
+## Does sshelf phone home?
+
+No. No telemetry, no account, no network calls of its own — the only network activity is the
+`ssh`/`sftp` it runs for you. See [Security](security.md).
+
+## Password auto-supply isn't working
+
+- Check `ssh -V` — you need OpenSSH 8.4+ (see above).
+- **Built from source on macOS?** An unsigned binary can hit a Keychain approval prompt on
+  every connect (Keychain ACLs are keyed to the code signature). Approve it, or ad-hoc sign
+  your build: `codesign -s - target/release/sshelf`.
+
+## I'm on a headless box with no keyring
+
+Set `SSHELF_VAULT_PASSPHRASE` — secrets then live in an `age`-encrypted vault file instead of
+a keyring. Details: [where secrets live](passwords-2fa.md#where-secrets-live); the
+env-inheritance tradeoff is documented in [Security](security.md).
+
+## Can a jump host use password auth?
+
+Not currently — jump hosts are key/agent only. The askpass helper holds the *target's* secret
+and can't tell which hop in a chain is prompting.
+
+## My 2FA host fails before I can type the code
+
+Flag it: **2FA = yes** in the edit form (or `--2fa` on `sshelf add`). A stored-secret connect
+routes *all* prompts to the askpass helper with no terminal fallback, so the verification
+prompt needs the [2FA flow](passwords-2fa.md#two-factor-2fa-hosts) to answer it.
+
+## Tab completion doesn't complete my host names
+
+Completion has two layers. The packages install **static** completion (subcommands + flags) —
+open a new shell so it loads. Completing your saved **host names** needs the dynamic engine
+sourced in your shell rc — one line per shell: [Shell completions](cli.md#shell-completions).
+
+## A forward vanished from F4
+
+`F4` only ever shows forwards whose processes are **actually running** — the list is
+reconciled against the OS on launch and refreshed live while open. If the tunnel died (
+reboot, sleep, network drop, killed from another terminal), it leaves the list; start it
+again with `Ctrl-f`. Automatic re-launch of dropped forwards isn't there yet.
+
+## How do I back up or sync my hosts?
+
+`hosts.toml` is one human-readable TOML file — keep it in your dotfiles like any config (a
+custom path is a setting: [Configuration](configuration.md)). **Secrets don't travel with
+it**: they're per-machine, in each machine's keyring or vault — re-add them with
+`sshelf set-password`. Frecency state is per-machine and app-managed.
+
+## Where did the first-connection host-key prompt go?
+
+Connections pass `StrictHostKeyChecking=accept-new`: a brand-new host's key is accepted and
+recorded on first use (so the prompt can't interfere with automated password supply), while a
+**changed** key for a known host still hard-fails, as ever. The tradeoff is discussed in
+[Security](security.md).
+
+## Windows?
+
+Not currently — connect hands off via Unix `exec()`, and the askpass/process plumbing is
+Unix-specific. macOS + Linux for now.

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -1,0 +1,58 @@
+# Adding & editing hosts
+
+`Ctrl-a` opens the add form; `Ctrl-e` edits the selected host. It's a single screen — every
+field shows a dim placeholder explaining it (`required ·` for Name/Hostname, `optional ·`
+elsewhere), and it's **auth-aware**: only the fields relevant to the chosen Auth method are
+shown.
+
+**Quick-add:** the form opens with sensible defaults, so a Name + Hostname and `Ctrl-s` is
+enough.
+
+## Fields
+
+Always shown: **Name** (required), **Hostname** (required), **User** (defaults to `$USER` at
+connect time), **Port** (defaults 22), **Auth**, **Jump hosts** (ProxyJump chain — key/agent
+auth only), **Tags**, **Site**, **2FA** (`←`/`→` yes/no — prompt for a verification code on
+connect), **Extra args** (raw ssh flags appended verbatim — the escape hatch for anything the
+form doesn't model, e.g. `-X` or `-o ServerAliveInterval=30`).
+
+Auth-specific fields:
+
+| Auth | Extra fields |
+|---|---|
+| `agent` (default) | none — ssh uses your agent/keys as usual |
+| `key` | **Key** — `←`/`→` cycles private keys found in `~/.ssh`; `Enter` opens a file browser to pick a key anywhere. **Key passphrase** — optional, only if the key is encrypted |
+| `password` | **Password** — stored in the OS keyring / vault, never in a file |
+
+Key discovery finds keypairs (a `.pub` sibling) **and** standalone private keys including
+`.pem` (detected by their `PRIVATE KEY` header), so AWS-style keys show up too.
+
+**The file browser** (from the Key field with `Enter`): type to fuzzy-filter, `↑`/`↓` move,
+`Enter` opens a directory or selects a file, `←` goes up, `Backspace` edits the filter (or
+goes up when it's empty), `Esc` clears the filter (or cancels when it's empty). It starts in
+`~/.ssh` (or near the current key); a picked key can live anywhere.
+
+## Navigating the form
+
+`Tab` / `↑` / `↓` move between fields · `←` / `→` (or space) change the choosers (Auth, Key,
+Site, 2FA) · `Enter` advances and **saves on the last field** · `Ctrl-s` saves from anywhere ·
+`Esc` cancels. Validation errors (missing name/hostname, non-numeric port) show inline, and
+focus jumps to the offending field.
+
+## Secrets in the form
+
+The masked **Password** / **Key passphrase** value goes to the OS keyring (or the age vault)
+keyed by host id — **never** into `hosts.toml`. When editing, leaving the field blank keeps
+the existing secret. Details: [Passwords, keys & 2FA](passwords-2fa.md).
+
+## Deleting
+
+`Ctrl-d` on the selected host asks for confirmation (`y`), then removes the host, its
+frecency history, and its stored secret.
+
+## Prefer the command line?
+
+Everything above can be done non-interactively with `sshelf add` — see
+[Adding hosts from the CLI](cli.md#adding-hosts-from-the-cli). `hosts.toml` itself is
+designed to be hand-edited too; the full schema is in [Data model & files](data-model.md)
+(that's also how you give one host **multiple** identity files).

--- a/docs/import.md
+++ b/docs/import.md
@@ -1,0 +1,23 @@
+# Importing from ~/.ssh/config
+
+`sshelf import` (or `Ctrl-o` in the TUI) copies hosts from `~/.ssh/config` into sshelf's own
+database. It is **strictly read-only**: sshelf parses the file and never writes back — your
+SSH config is not touched, ever.
+
+```sh
+sshelf import --dry-run    # preview what would be imported
+sshelf import              # import
+```
+
+What it does:
+
+- adds every host whose **name isn't already present** in sshelf — re-running is safe,
+  existing names are left alone;
+- carries over the fields sshelf models (hostname, user, port, identity files);
+- **warns** about directives it doesn't import — `Match`, `Include`, `ProxyJump` — instead of
+  silently mis-importing them.
+
+Import brings everything in at once (there's no per-host picker); curate afterwards with
+`Ctrl-e` / `Ctrl-d`, and organize with tags or [sites](sites-tags.md). Your `~/.ssh/config`
+keeps working exactly as before — sshelf's database is independent of it by design (the
+[FAQ](faq.md#why-doesnt-sshelf-just-use-my-ssh-config) explains why).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,29 +1,51 @@
-# `sshelf` documentation
+# sshelf
 
-`sshelf` is a TUI for managing and connecting to SSH hosts. It keeps its own host database
-and generates the correct `ssh` command for each node — it never edits `~/.ssh/config`.
+A fast terminal UI for managing and connecting to SSH hosts. Save each node once, then
+fuzzy-search and connect in two keystrokes.
 
-> **Docs-in-sync rule:** every code/behavior change updates the relevant doc here in the same
-> change, and appends to [`progress.md`](./progress.md). See [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+![sshelf — fuzzy-search your SSH hosts and connect in two keystrokes](./sshelf-readme.gif)
 
-## Contents
+**sshelf keeps its own host database and generates the correct `ssh` command for you — it
+never reads or edits `~/.ssh/config`** (except an explicit, read-only import). No account, no
+cloud, no telemetry: your hosts live in a human-readable TOML file on your disk, secrets live
+in your OS keyring, and the only network activity is the `ssh` it hands your terminal to.
 
-| Doc | What it covers |
-|---|---|
-| [progress.md](./progress.md) | Living log — current milestone, what changed, what's next. **Start here.** |
-| [architecture.md](./architecture.md) | How the pieces fit: launcher/`exec()` model, askpass flow, secret store, data flow. |
-| [structure.md](./structure.md) | Module/file map and responsibilities. |
-| [data-model.md](./data-model.md) | `Host` schema, config/state files, on-disk locations & formats. |
-| [ssh-command.md](./ssh-command.md) | Flag mapping (`-i`/`-p`/`-J`/extra-args) and the `SSH_ASKPASS` password mechanism. |
-| [ux.md](./ux.md) | Screens, keybindings, wizard flow, theming. |
-| [decisions.md](./decisions.md) | Decision log (ADR-style) with rationale. |
-| [security.md](./security.md) | Threat model for stored secrets (mirrors the shipped `SECURITY.md`). |
-| [packaging.md](./packaging.md) | Shipping to Homebrew, Debian/Ubuntu (`.deb`/apt), and crates.io — multi-arch (x86 + arm). |
+## Get started
 
-## Quick orientation
+```sh
+brew install max-rh/tap/sshelf     # macOS or Linux
+sshelf                             # launch the TUI
+```
 
-- **What it is:** a fast, atuin-style fuzzy launcher for SSH. Save a host once, connect with `Enter`.
-- **What it is NOT:** it does not edit `~/.ssh/config`, is not a terminal emulator, and does
-  not proxy/tunnel traffic itself — it builds the `ssh` invocation and hands the terminal to `ssh`.
-- **Platforms:** macOS + Linux (v1). **Toolchain:** Rust 1.88+.
-- **Status:** see [progress.md](./progress.md).
+- **[Install](install.md)** — Homebrew, shell installer, `.deb`, `.rpm`, Gentoo, or cargo.
+- **[Quickstart](quickstart.md)** — the first five minutes: add or import hosts, connect.
+- **[FAQ & troubleshooting](faq.md)** — common questions, quick answers.
+
+## What's in the box
+
+- An atuin-style **fuzzy launcher** with frecency ordering — [Searching & connecting](search-connect.md)
+- A dual-pane **SFTP file browser** (`Ctrl-t`) — [Transferring files](transfer.md)
+- Background **port forwards** that survive quitting (`Ctrl-f` / `F4`) — [Port forwarding](port-forwarding.md)
+- **Sites** with a shared bastion + defaults, plus free-form tags (`F3`) — [Sites & tags](sites-tags.md)
+- Stored **passwords/passphrases** auto-supplied at connect, and **2FA** code prompts —
+  [Passwords, keys & 2FA](passwords-2fa.md)
+- A scriptable **CLI** (`sshelf add`, `list --json`, `print-command`, …) — [CLI reference](cli.md)
+
+Platforms: **macOS + Linux**, x86_64 and arm64. Runtime: **OpenSSH 8.4+** for password
+auto-supply.
+
+## How it's built
+
+Deciding whether to trust it — or just curious how the pieces fit?
+
+- [Security & threat model](security.md) — exactly what stored secrets are protected
+  against, and what they are not.
+- [How the ssh command is built](ssh-command.md) — argv generation and the `SSH_ASKPASS`
+  mechanism that supplies passwords without `sshpass`.
+
+## Contributing
+
+Start with [`CONTRIBUTING.md`](https://github.com/max-rh/sshelf/blob/master/CONTRIBUTING.md),
+then the **Development** section in the sidebar: architecture, module map, data model, and the
+decision log. Docs follow the docs-in-sync rule — every behavior change updates the relevant
+page here in the same change, with a dated entry in the [progress log](progress.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,66 @@
+# Install
+
+sshelf runs on **macOS and Linux**, x86_64 and arm64. The prebuilt packages need **no Rust
+toolchain**; at runtime sshelf wants **OpenSSH 8.4+** on your machine (password auto-supply
+rides on `SSH_ASKPASS_REQUIRE`, added in OpenSSH 8.4 — see the [FAQ](faq.md) if unsure).
+
+## Homebrew (macOS or Linux)
+
+```sh
+brew install max-rh/tap/sshelf
+```
+
+## Shell installer
+
+Downloads the prebuilt binary for your platform:
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/max-rh/sshelf/releases/latest/download/sshelf-installer.sh | sh
+```
+
+## Debian / Ubuntu (`.deb`)
+
+Grab the `.deb` for your architecture from the
+[latest release](https://github.com/max-rh/sshelf/releases/latest), then:
+
+```sh
+sudo apt install ./sshelf_*_amd64.deb      # or *_arm64.deb
+```
+
+## Fedora / RHEL / Rocky / openSUSE (`.rpm`)
+
+The `.rpm` is a static build, so one package runs on any RPM distro regardless of glibc.
+Grab it from the [latest release](https://github.com/max-rh/sshelf/releases/latest), then:
+
+```sh
+sudo dnf install ./sshelf-*.x86_64.rpm     # or .aarch64.rpm
+```
+
+## Gentoo
+
+Via the community-maintained Masterwolf overlay (unofficial; thanks to
+[@masterwolf-git](https://github.com/masterwolf-git)):
+
+```sh
+eselect repository enable masterwolf
+emerge --sync
+emerge --ask app-admin/sshelf
+```
+
+## Cargo (crates.io)
+
+Needs **Rust 1.88+**:
+
+```sh
+cargo install sshelf
+```
+
+## After installing
+
+- **Shell tab-completion** (subcommands + flags) ships with every package — open a **new
+  shell** (or `exec $SHELL`) so it loads. Completion of your saved **host names** takes one
+  more line in your shell rc: see [Shell completions](cli.md#shell-completions).
+- On Linux, secrets use the **Secret Service** (GNOME Keyring / KWallet) through a pure-Rust
+  backend — no `libdbus` or OpenSSL packages needed. On a headless box with no keyring, see
+  [the age vault](passwords-2fa.md#where-secrets-live).
+- Next stop: the [Quickstart](quickstart.md).

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -26,7 +26,7 @@ GitHub user is **`max-rh`**; the repo is `github.com/max-rh/sshelf`; the Homebre
 3. [Homebrew + tarballs via dist](#3-homebrew--tarballs-via-dist)
 4. [Debian/Ubuntu `.deb`](#4-debianubuntu-deb)
 5. [Shell completions & man page (clap)](#5-shell-completions--man-page)
-6. [macOS code signing & notarization](#6-macos-code-signing--notarization)
+6. [macOS signing — no Apple program needed](#6-macos-signing--and-why-you-dont-need-the-99-apple-program)
 7. [Cross-compilation reference](#7-cross-compilation-reference)
 8. [Release checklist](#8-release-checklist)
 9. [Appendix: manual Homebrew formula & APT repo](#9-appendix)

--- a/docs/passwords-2fa.md
+++ b/docs/passwords-2fa.md
@@ -1,0 +1,71 @@
+# Passwords, keys & 2FA
+
+> **Prefer SSH keys / agent where you can.** Password storage exists for hosts you can't use
+> keys with; it is the least secure option sshelf offers. The full threat model:
+> [Security](security.md).
+
+## Auth methods
+
+Each host uses one auth method, chosen in the [add/edit form](hosts.md):
+
+- **`agent`** (default) — ssh uses your keys/agent as usual; sshelf stores nothing.
+- **`key`** — one or more `-i` identity files. If the key is **encrypted**, you can store its
+  passphrase and sshelf supplies it automatically at connect.
+- **`password`** — sshelf stores the login password and supplies it automatically.
+
+## Where secrets live
+
+- **OS keyring** (default): macOS Keychain, or the Secret Service on Linux (GNOME Keyring /
+  KWallet). Service `sshelf`, keyed by host id.
+- **The age vault** (headless): if `SSHELF_VAULT_PASSPHRASE` is set, secrets go to an
+  `age`-encrypted file (`vault.age`, mode `0600`) instead — the path for servers and CI with
+  no keyring daemon. The tradeoffs are documented in [Security](security.md).
+
+Never in `hosts.toml`, never on a command line, never in logs or shell history.
+
+## How auto-supply works
+
+On connect, sshelf points `SSH_ASKPASS` at itself and `exec`s `ssh`. When ssh needs the
+secret it invokes that helper, which answers **only** genuine password/passphrase prompts
+(matched by their shape) and declines everything else — so a hostile server can't phish the
+secret with a look-alike prompt, and the secret never appears in `ps` or on disk. The full
+mechanics — and why this needs OpenSSH 8.4+ — are in
+[How the ssh command is built](ssh-command.md).
+
+## Storing & changing a secret
+
+- **In the form:** the masked Password / Key passphrase field. When editing, blank keeps the
+  existing secret.
+- **From a script / headless:**
+
+```sh
+echo "$PASS" | sshelf set-password prod-db        # store or replace after the fact
+echo "$PASS" | sshelf add legacy -H 10.0.0.9 -u root --password-stdin
+```
+
+Deleting a host removes its stored secret too.
+
+## Two-factor (2FA) hosts
+
+Some servers ask for a verification code (TOTP / keyboard-interactive) on top of your key or
+password. Set **2FA = yes** on the host (form, or `sshelf add … --2fa`):
+
+- **TUI connect:** a popup collects the current code *before* the ssh handoff and feeds it to
+  the server's verification prompt through the same askpass channel. sshelf never proxies the
+  live session.
+- **CLI connect** (`sshelf <host>`): prompts for the code on the terminal.
+
+Codes are **manual entry** — sshelf does not store TOTP seeds. The flag exists because a
+connect that auto-supplies a stored secret runs ssh with `SSH_ASKPASS_REQUIRE=force`, which
+routes the code prompt to the helper with **no terminal fallback** — unflagged, such a
+connect fails at the code prompt. (A host with no stored secret prompts inline anyway; a host
+that combines an encrypted key with 2FA but no stored passphrase is better served by the
+agent.) Background: [`decisions.md`](decisions.md), D-022.
+
+## Limitations worth knowing
+
+- **Jump hosts must use key/agent auth.** The askpass helper only holds the *target's* secret
+  and can't tell which hop is prompting.
+- **Building from source on macOS:** an unsigned binary may trigger a Keychain approval
+  prompt on connect (Keychain ACLs are keyed to the code signature) — see the
+  [FAQ](faq.md#password-auto-supply-isnt-working).

--- a/docs/port-forwarding.md
+++ b/docs/port-forwarding.md
@@ -1,0 +1,52 @@
+# Port forwarding
+
+`Ctrl-f` on a host starts an SSH tunnel that **keeps running after you quit sshelf** — set it
+up, close the TUI (or the whole terminal), and it stays up until you stop it or it drops.
+
+## Creating a forward (`Ctrl-f`)
+
+Pick a kind (cycle with `←`/`→`):
+
+- **Local** (`-L`, the default) — a local port that tunnels to something reachable *from the
+  server*. E.g. reach the server's private database as `127.0.0.1:8080` on your machine.
+- **Remote** (`-R`) — a port *on the server* that tunnels back to something reachable from
+  your machine. E.g. let someone on the server's network reach a dev server on your laptop.
+- **Dynamic** (`-D`) — a local **SOCKS proxy** that routes traffic through the server.
+
+Fill in the ports/host — defaults: bind `127.0.0.1`, target host `localhost` — and press
+`Ctrl-s`. sshelf spawns a detached `ssh -N …` reusing the host's auth exactly as connect does
+(keys/agent/ProxyJump, stored password, [site defaults](sites-tags.md)), then waits briefly
+to confirm the tunnel actually bound. A failure is shown in the popup so you can fix a field
+and retry:
+
+- **local port already in use** — pick another port;
+- **privileged port** — ports below 1024 need root; use 1024 or higher;
+- **server refused the remote bind** — the server's `sshd` controls remote binds
+  (`GatewayPorts`);
+- authentication / DNS failures, reported as-is.
+
+On success you're back at the list and the tunnel runs on its own.
+
+## The forwards manager (`F4`)
+
+Lists **every active forward across all hosts** — host, a summary like
+`L  127.0.0.1:8080 → db:3306`, pid, and age.
+
+| Key | Action |
+|---|---|
+| `↑` / `↓`, `Ctrl-p` / `Ctrl-n` | move the selection |
+| `d` (or `k`), then `y` | stop the selected forward |
+| `Esc` / `Ctrl-s` / `Ctrl-c` | close the manager |
+
+The list refreshes live and is **reconciled against the actually-running processes**: a
+forward that ends — stopped here, `kill`ed from another terminal, or dropped on its own after
+sleep or network loss — disappears within a moment, and on every launch sshelf shows only
+forwards that are still really up. The ledger lives in `forwards.json`
+([data model](data-model.md)), but the processes are authoritative — the file is just
+remembered PIDs. Design details: [`decisions.md`](decisions.md), D-021.
+
+## Why they survive
+
+Each forward is its own detached process in its own process group, with no tie to sshelf or
+your terminal: quitting sshelf orphans it (fine), and closing the terminal doesn't hang it
+up. Stop one from `F4` — or `kill <pid>` works too; sshelf notices either way.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -3,8 +3,29 @@
 Reverse-chronological. Newest entry on top. Every change to the project adds an entry here
 (the docs-in-sync rule). Keep entries short: what changed, why, and what's next.
 
-**Current milestone:** Distribution — publish to crates.io and ship `.rpm` packages, plus a leaner
-published crate. (Interactive 2FA shipped in v0.8.0.)
+**Current milestone:** Docs — the site now opens with a user guide; the README is a landing
+page. (crates.io + `.rpm` shipped in v0.9.0.)
+
+---
+
+## 2026-07-06 — Docs: user guide split from internals; slim README
+
+- The mdBook site now leads with a **Guide** for users: install, quickstart, adding/editing
+  hosts, searching & connecting, file transfer, port forwarding, sites & tags,
+  passwords/keys/2FA, import, a full CLI reference, configuration, and an FAQ. Content that
+  previously lived only in the README (CLI flag table, completions setup, config reference) or
+  inside `ux.md` moved into these pages; `index.md` is a product landing page instead of a doc
+  inventory, and `SUMMARY.md` is reorganized into Guide / Understanding sshelf / Development.
+- `ux.md` slimmed to **UI design notes** (visual model, ranking, form design, modality,
+  theming) — stale milestone markers removed; behavior and keybindings are documented in the
+  Guide pages, which the docs-in-sync rule in `CONTRIBUTING.md` now points at.
+- README cut from ~230 to ~140 lines: pitch, install (secondary channels folded into a
+  `<details>`), a "first five minutes" block, and links into the site; added crates.io/CI/
+  license badges and an explicit no-telemetry / no-account / no-cloud line. Everything removed
+  now lives on the site.
+- Why: the README had become the user manual because the site didn't have one, while the site
+  led with contributor docs — and the site is the crates.io homepage, so a real guide is what
+  visitors should land on. Docs-only change; no code touched.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart
+
+The first five minutes with sshelf.
+
+## 1. Launch
+
+```sh
+sshelf
+```
+
+The first run writes a commented `config.toml` under `~/.config/sshelf/`. You land in the
+(empty) host list — **`F1` shows every key** at any time.
+
+## 2. Add a host — or import the ones you already have
+
+Press **`Ctrl-a`**: the add form opens with sensible defaults, so typing a **Name** and a
+**Hostname** and pressing `Ctrl-s` is enough for a first host. Auth, jump hosts, tags, and
+the rest are covered in [Adding & editing hosts](hosts.md).
+
+Already have hosts in `~/.ssh/config`? Import them — **read-only**, sshelf copies them into
+its own database and never writes your config:
+
+```sh
+sshelf import --dry-run    # preview what would be imported
+sshelf import              # do it (or press Ctrl-o in the TUI)
+```
+
+## 3. Connect
+
+Type a few characters to fuzzy-filter, `Enter` to connect. sshelf records your usage and then
+**`exec`s into `ssh`** — the TUI is gone and it's a plain ssh session; when it ends you're
+back at your shell. The hosts you use most float to the top of the idle list.
+
+## 4. Connect even faster
+
+```sh
+sshelf prod-web            # straight to a saved host by name — no TUI
+sshelf -                   # reconnect to the most recently used host
+```
+
+## 5. Know where your data lives
+
+Your hosts are one human-readable TOML file — `~/.config/sshelf/hosts.toml` — safe to
+hand-edit and to keep in your dotfiles. Secrets are **not** in it: they live in your OS
+keyring or an encrypted vault ([Passwords, keys & 2FA](passwords-2fa.md)).
+
+## Where to next
+
+- [Searching & connecting](search-connect.md) — `tag:`/`site:` filters, frecency, yanking
+  the generated command.
+- [Transferring files](transfer.md) — the dual-pane SFTP browser (`Ctrl-t`).
+- [Port forwarding](port-forwarding.md) — background tunnels that outlive the TUI (`Ctrl-f`).
+- [CLI reference](cli.md) — scripting: `add`, `list --json`, `print-command`, completions.

--- a/docs/search-connect.md
+++ b/docs/search-connect.md
@@ -1,0 +1,59 @@
+# Searching & connecting
+
+The list screen is a fuzzy launcher in the style of atuin: the search box is **always
+active**, so plain typing filters the list, and actions use **Ctrl** or function keys.
+
+## Filtering
+
+- **Type** — fuzzy match against your hosts; matched characters are highlighted.
+- **`tag:NAME`** — only hosts with that tag. Repeat and combine with text
+  (`tag:prod tag:db` is an AND).
+- **`site:NAME`** — only hosts in that [site](sites-tags.md).
+
+## Ordering
+
+- **Idle (no query):** hosts sort by **frecency** — usage count decayed by recency, so your
+  daily drivers sit at the top. The decay rate is configurable, and `default_sort = "name"`
+  opts out entirely ([Configuration](configuration.md)). The idle list also **groups by
+  site** (`── site (n) ──` headers, `(no site)` last).
+- **Filtering:** best fuzzy match first; frecency breaks ties. The list is flat, with a dim
+  `·site·` column.
+
+## Keys
+
+| Key | Action |
+|---|---|
+| _type_ | filter the list (fuzzy text, `tag:` / `site:` tokens) |
+| `↑` / `↓`, `Ctrl-p` / `Ctrl-n` | move the selection |
+| `Enter` | connect to the selected host |
+| `Ctrl-a` / `Ctrl-e` / `Ctrl-d` | [add / edit / delete](hosts.md) a host |
+| `Ctrl-y` | **yank** — copy the generated `ssh` command without connecting |
+| `Ctrl-t` | [transfer files](transfer.md) to/from the selected host |
+| `Ctrl-f` | [port-forward](port-forwarding.md) through the selected host |
+| `Ctrl-o` | [import](import.md) from `~/.ssh/config` (read-only) |
+| `F1` | help overlay — every key, in the TUI itself |
+| `F2` | settings ([Configuration](configuration.md)) |
+| `F3` | manage [sites](sites-tags.md) |
+| `F4` | manage [port forwards](port-forwarding.md#the-forwards-manager-f4) |
+| `Esc` | clear the query if non-empty, otherwise quit |
+| `Ctrl-c` | quit |
+
+## What "connect" actually does
+
+`Enter` records the host's usage (for frecency), tears the TUI down, and **`exec`s into
+`ssh`** — sshelf is *replaced* by the real ssh process, so there is no wrapper between you
+and your session, and when the session ends you're back at your shell. The command it runs is
+exactly what `Ctrl-y` (or `sshelf print-command <host>`) shows: plain flags built from the
+host's fields plus any inherited [site defaults](sites-tags.md) — no temporary config files.
+Full mechanics: [How the ssh command is built](ssh-command.md).
+
+## Connecting without the TUI
+
+```sh
+sshelf prod-web       # connect by name (or id) — same path as Enter
+sshelf -              # reconnect to the most recently used host
+```
+
+A miss suggests the closest matching names; a host named like a subcommand (`list`,
+`import`, …) is reached via the TUI instead. The rest of the CLI:
+[CLI reference](cli.md).

--- a/docs/sites-tags.md
+++ b/docs/sites-tags.md
@@ -1,0 +1,47 @@
+# Sites & tags
+
+Two ways to organize hosts:
+
+- **Tags** — free-form, many per host (`prod`, `db`, `web`). Pure labels: filter with
+  `tag:NAME`, repeatable and ANDed.
+- **A site** — **one** per host (a data center, a project, a customer). Sites group the idle
+  list, filter with `site:NAME` — and can optionally carry **shared SSH defaults** that
+  member hosts inherit.
+
+## Site defaults & inheritance
+
+A site may define a default **user**, **port**, **jump host(s)** (the site's bastion), and
+**identity file(s)**. At connect time each member host is resolved against them:
+
+- the site's value fills in **only where the host leaves that field unset** — the host
+  always wins;
+- **auth is never inherited** — it stays per-host;
+- a bare site (name only) is pure grouping.
+
+Inherited defaults show up everywhere the command does: connect, `Ctrl-y` yank,
+`sshelf print-command`, transfers, forwards. A host that names an *undefined* site still
+groups under that name — it just inherits nothing.
+
+## In the list
+
+Idle (empty search box): hosts group under `── site (n) ──` headers, with `(no site)` last.
+While filtering: a flat list with a dim `·site·` column; `site:NAME` narrows to one site.
+
+## Managing sites (`F3`)
+
+`a` add · `e`/`Enter` edit · `d` delete · `Ctrl-s` save · `Esc` cancel. Each site's form is a
+name plus the optional defaults. **Renaming** a site updates its member hosts; **deleting**
+one clears its members' site — nothing dangles. Assign a host's site in the
+[add/edit form](hosts.md) (`←`/`→` over the defined sites + `(none)`).
+
+## From the CLI
+
+```sh
+sshelf sites                                        # sites, member counts, their defaults
+sshelf sites --json                                 # machine-readable
+sshelf sites add prod-dc -u deploy -J bastion.prod  # define a site with shared defaults
+sshelf add web1 -H 10.0.0.4 --site prod-dc          # add a host into it
+sshelf list site:prod-dc                            # filter by site
+```
+
+Storage: `[[site]]` entries in `hosts.toml` — see [Data model & files](data-model.md).

--- a/docs/transfer.md
+++ b/docs/transfer.md
@@ -1,0 +1,46 @@
+# Transferring files
+
+`Ctrl-t` on a host opens a **dual-pane transfer screen**: your local files on one side, the
+host's on the other. Copy files or whole folders in either direction over SFTP, with fuzzy
+search on both sides and live progress.
+
+sshelf authenticates **once**: it opens an `ssh` ControlMaster that reuses the host's normal
+auth (keys/agent/ProxyJump — or the stored password, supplied the same way as on connect) and
+runs `sftp` over it. No per-file re-prompts, and `~/.ssh/config` is never touched. Remote
+listing and transfers run on a background thread, so the UI stays responsive on slow links.
+
+## Keys
+
+| Key | Action |
+|---|---|
+| _type_ | filter the focused pane |
+| `Tab` | switch the focused pane (local ↔ remote) |
+| `↑` / `↓`, `Ctrl-p` / `Ctrl-n` | move the selection |
+| `→` / `Enter` | open the selected directory (on a file: send it) |
+| `Ctrl-s` | **send** the selected file or folder (recursive) into the other pane's directory |
+| `←` | go up a directory |
+| `Backspace` | edit the filter, or go up when it's empty |
+| `Esc` | cancel a running transfer, else clear the filter, else close the screen |
+
+## Behavior & limits
+
+- Directories are shown as `name/` and symlinks as `name@` — **symlinks are skipped**.
+- A same-named file or folder already present in the destination is **skipped** (with a
+  message), never overwritten.
+- One transfer runs at a time. Single-file downloads show bytes + percent; folders and
+  uploads show as in-flight (cancelable with `Esc`).
+- Filenames are shell-quoted (spaces are fine) and control characters are stripped from
+  display.
+- The connection uses `StrictHostKeyChecking=accept-new`, like connect: a first-time host key
+  is trusted on first use, a **changed** key still hard-fails. See [Security](security.md).
+
+## Debugging a failing transfer
+
+The status line shows the underlying `sftp` error. For the full story:
+
+```sh
+sshelf --transfer-log /tmp/sshelf-transfer.log     # or $SSHELF_TRANSFER_LOG
+```
+
+This appends every `ssh`/`sftp` command and its stderr to the file. **No secrets are
+logged** — passwords reach `ssh` via `SSH_ASKPASS`, never the command line.

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -1,264 +1,53 @@
-# UX: screens, keys, wizard, theming
+# UI design notes
 
-Visual model is atuin.sh: slim chrome, an inline filter-as-you-type list, and a contextual
-keybind hint bar at the bottom.
+How the interface is designed and why. **What each screen does — and every keybinding — is
+documented in the user Guide** ([Searching & connecting](search-connect.md),
+[Adding & editing hosts](hosts.md), [Transferring files](transfer.md),
+[Port forwarding](port-forwarding.md), [Sites & tags](sites-tags.md)); this page holds the
+design rationale and rendering details behind those screens.
 
-## Main screen (host list)
+## Visual model
 
-```
-┌ sshelf  3/14 ───────────────────────────────────────┐
-│ > prod                                               │   ← live fuzzy filter input (top)
-└──────────────────────────────────────────────────────┘
-┌──────────────────────────────────────────────────────┐
-│ ▸ prod-web       deploy@web1:2222       [prod]       │   ← selected row, matched chars bold
-│   prod-db        mike@10.25.25.25       [prod,db]    │
-│   prod-cache     mike@10.0.0.9          [prod]       │
-└──────────────────────────────────────────────────────┘
- ↵ connect  ^a add  ^e edit  ^d delete  ^y yank  ^o import  F1 help  esc quit
-```
+atuin.sh: slim chrome, an inline filter-as-you-type list, and a contextual keybind hint bar
+at the bottom. The search box is **always active** (single-mode, no insert/normal split), so
+plain letters filter the list; actions therefore use **Ctrl** or function keys, which can't
+be typed into the query.
 
-Layout: `Length(3)` search · `Min(0)` list · `Length(1)` hint bar. Each row shows
-`name · user@host[:port] · [tags]`. The `matched/total` count lives in the search-box
-title (so it's never truncated by a narrow terminal).
+Main screen layout: `Length(3)` search · `Min(0)` list · `Length(1)` hint bar. Each row shows
+`name · user@host[:port] · [tags]`, plus a dim `·site·` column while filtering. The
+`matched/total` count lives in the search-box *title* so it's never truncated by a narrow
+terminal.
 
-### Sorting / ranking
+## Sorting / ranking
 
-- **No query (idle):** sort by **frecency** desc (most-used-recently first).
-  `score = use_count * exp(-decay_rate * days_since_last_used)`, `decay_rate` default `0.2`.
-- **Typing a query:** fuzzy-filter via `nucleo-matcher`; sort by match score; **frecency
-  breaks ties**. Matched characters are highlighted (bold/accent) using the matcher's match
-  indices, rendered with `unicode-width` so wide/combining chars don't misalign.
-- v1 ships fuzzy search only (prefix/substring modes can come later).
+- **No query (idle):** frecency desc —
+  `score = use_count * exp(-decay_rate * days_since_last_used)`, `decay_rate` default `0.2`
+  (`default_sort = "name"` opts out). The idle view groups by site.
+- **Typing:** fuzzy-filter via `nucleo-matcher`; sort by match score with frecency breaking
+  ties. Matched characters are highlighted (bold/accent) using the matcher's match indices,
+  rendered with `unicode-width` so wide/combining characters don't misalign.
+- Fuzzy only for now (prefix/substring modes can come later).
 
-## Keybindings (list screen)
+## The add/edit form
 
-The search box is **always active** (atuin-style single mode), so plain letters filter the
-list. Actions therefore use **Ctrl** (or function keys) to avoid being typed into the query.
+A single-screen, **auth-aware** field form rather than a paged wizard — simpler to navigate
+and edit, "guided" by dim placeholders (`required ·` / `optional ·`) and inline validation
+with focus jumping to the offending field. Fields specific to an auth method only render for
+that method. The Key field is a picker (single key) backed by a fuzzy file-browser modal;
+key discovery matches keypairs (`.pub` sibling) *and* standalone private keys by their
+`PRIVATE KEY` header so `.pem` files show up. A host configured with multiple identity files
+keeps them on edit; entering several is done by editing `hosts.toml`.
 
-| Key | Action |
-|---|---|
-| _type_ | filter the list (fuzzy) |
-| `tag:NAME` | filter by tag; combine with text and repeat (`tag:prod tag:db`, AND) |
-| `site:NAME` | filter by site (one site per host) |
-| `↑` / `↓`, `Ctrl-p` / `Ctrl-n` | move selection |
-| `Enter` | connect to selected host (tears down TUI, `exec()`s ssh) — M3 |
-| `Ctrl-a` | add host (wizard) — M4 |
-| `Ctrl-e` | edit selected host — M4 |
-| `Ctrl-d` | delete selected host (confirm) — M4 |
-| `Ctrl-y` | yank — copy/print the generated `ssh` command without connecting — M3 |
-| `Ctrl-t` | open the dual-pane **file-transfer** screen for the selected host |
-| `Ctrl-f` | open the **port-forward** popup for the selected host (runs in the background) |
-| `Ctrl-o` | import from `~/.ssh/config` (read-only) — M7 |
-| `F1` | help overlay |
-| `F2` | settings (config & hosts-file locations) |
-| `F3` | manage sites (create/edit/delete groups + their shared defaults) |
-| `F4` | manage **port forwards** (list all active, stop any) |
-| `Esc` | clear the query if non-empty, otherwise quit |
-| `Ctrl-c` | quit |
+## Modality & precedence
 
-Implemented in M2: type-to-filter, navigation, `Enter` (returns a Connect outcome), `F1`
-help, `Esc`/`Ctrl-c`. The action keys show a "coming in Mx" status until their milestone.
-Tag filtering and `config.toml` keybinding overrides land in M6.
-
-## Add / Edit form
-
-A single full-screen form (`Ctrl-a` add, `Ctrl-e` edit selected). Every field shows a dim
-**placeholder** explaining it. The form is **auth-aware** — it shows only the fields relevant
-to the chosen Auth method, so the rest don't clutter the screen.
-
-Always shown: **Name** (required), **Hostname** (required), **User** (defaults `$USER`),
-**Port** (defaults 22), **Auth**, **Jump hosts**, **Tags**, **Site**, **2FA** (`←`/`→` yes/no —
-prompt for a verification code on connect), **Extra args** (raw flags escape hatch).
-
-Auth-specific fields:
-
-| Auth | Extra fields |
-|---|---|
-| `agent` | none |
-| `key` | **Key** — `←`/`→` cycles private keys found in `~/.ssh`, **`Enter` opens a file browser** to pick a key anywhere (e.g. a `.pem` in `~/Downloads`); **Key passphrase** — optional, only if the key is encrypted |
-| `password` | **Password** |
-
-Key discovery finds keypairs (`<name>.pub` sibling) **and** standalone private keys including
-`.pem` (detected by a `PRIVATE KEY` header), so AWS-style keys show up too. Every field shows a
-dim placeholder, prefixed `optional ·` when the field can be left blank (`required ·` for Name/Hostname).
-
-**File browser** (opened from the Key field with `Enter`): a modal listing the current
-directory with a fuzzy filter — **type to filter**, `↑`/`↓` move, `Enter` opens a directory or
-selects a file, `←` goes up, `Backspace` edits the filter (or goes up when empty), `Esc` clears
-the filter (or cancels when empty). It starts in `~/.ssh` (or near the current key) and a picked
-path is stored as the host's identity, even if it's outside `~/.ssh`. Key discovery finds `.pem`
-and other private keys by their header, not just `.pub` pairs.
-
-## Settings (`F2`)
-
-A screen for configuring sshelf itself. v1:
-
-- **Config file** — shown read-only (it's chosen *before* the config is read, via `--config` /
-  `$SSHELF_CONFIG`, so it can't be a setting in the file itself).
-- **Hosts file** — editable; blank means the default under the config dir. `~` is expanded.
-  On save, an *existing* file at the new path is **adopted** (loaded, never overwritten); a new
-  path is created from the current hosts so they follow. More settings will be added here.
-
-Navigation: `Tab` / `↑` / `↓` move between fields; `←` / `→` (or space) change the choosers
-(Auth, Key); `Enter` advances and **saves on the last field**; `Ctrl-s` saves anywhere; `Esc`
-cancels. Validation errors (missing name/hostname, non-numeric port) show inline and focus
-jumps to the offending field.
-
-> Implemented as a single-screen, auth-aware field form (not a paged wizard) — simpler to
-> navigate/edit and "guided" by placeholders + inline validation. The Key field is a picker
-> (single key); a host configured with **multiple** identity files keeps them on edit, but
-> entering several keys is done by editing `hosts.toml`.
-
-**Quick-add:** the form opens with defaults, so typing a Name + Hostname and `Ctrl-s` is enough.
-
-**Secrets (Password / Key passphrase):** the masked value is stored in the OS keyring (or the
-age vault) keyed by host id — **never** in `hosts.toml`. On edit, leaving it blank keeps the
-existing secret. It's auto-supplied at connect time (see `ssh-command.md`). Deleting a host
-(`Ctrl-d`) removes the host, its frecency entry, and its stored secret.
-
-## Sites (`F3`)
-
-A **site** groups hosts (one per host — a data center / project) and, unlike tags, may carry
-**optional** shared SSH defaults — user, port, ProxyJump (bastion), identity — that member hosts
-inherit at connect time. A bare site (name only) is pure grouping; per-host fields always
-override the site's; auth stays per-host.
-
-- **In the list:** with an empty search box, hosts are grouped under `── site (n) ──` headers
-  (a `(no site)` group last); while filtering, the list is flat with a dim `·site·` column and a
-  `site:NAME` filter token.
-- **Assigning a site:** the add/edit form has a **Site** chooser (`←`/`→` over the defined sites
-  + `(none)`).
-- **Managing sites (`F3`):** a list with `a` add, `e`/`Enter` edit, `d` delete, `Ctrl-s` save,
-  `Esc` cancel. Each site's form is name + optional user/port/jump/identity. Renaming a site
-  updates its member hosts; deleting one clears members' site (nothing dangles). A host that names
-  an undefined site still groups under that name but inherits nothing.
-
-Inherited defaults appear in the generated command (yank, `print-command`, connect, transfers).
-
-## Import (`Ctrl-o` / `sshelf import`)
-
-Parses `~/.ssh/config` **read-only** via `ssh2-config` and adds every host whose name isn't
-already present, warning about unsupported `Match` / `Include` / `ProxyJump`. v1 imports all
-new hosts at once (no per-host selection screen) — curate afterwards with `Ctrl-e` / `Ctrl-d`.
-The CLI form supports `--dry-run` to preview. Never writes back to `~/.ssh/config`.
-
-## File transfer (`Ctrl-t`)
-
-`Ctrl-t` on a host opens a **dual-pane transfer screen**: local files on the left, the host's
-files on the right. sshelf authenticates **once** by opening an `ssh` ControlMaster that reuses
-the host's auth (keys/agent/ProxyJump, or the stored keyring/vault secret via `SSH_ASKPASS`),
-then runs `sftp` (`ls`/`get`/`put`) over it. Remote listing and transfers run on a background
-thread, so the UI stays responsive on slow links.
-
-Both panes fuzzy-filter as you type:
-
-| Key | Action |
-|---|---|
-| _type_ | filter the focused pane |
-| `Tab` | switch the focused pane (local ↔ remote) |
-| `↑` / `↓`, `Ctrl-p` / `Ctrl-n` | move the selection |
-| `→` / `Enter` | open the selected directory (or send a file) |
-| `Ctrl-s` | **send** the selected file or folder (recursive) into the *other* pane's directory |
-| `←` | go up a directory |
-| `Backspace` | edit the filter, or go up when it's empty |
-| `Esc` | cancel a running transfer, else clear the filter, else close the screen |
-
-A progress bar shows bytes and percent for single-file downloads; folder and upload transfers
-show as in-flight (cancelable with `Esc`). Directories are marked `name/` and symlinks `name@`;
-symlinks are skipped in this version. Filenames are shell-quoted and control characters stripped
-from display. The connection uses `StrictHostKeyChecking=accept-new`, like connect — so a
-first-time host key is trusted on use (see [`security.md`](security.md)). Only one transfer runs
-at a time in v1, and a same-named file or folder already present in the destination is **skipped**
-(with a message) rather than overwritten.
-
-On failure the status line shows the underlying `sftp` error. For more detail, run with
-`sshelf --transfer-log <FILE>` (or `$SSHELF_TRANSFER_LOG=<FILE>`): the worker appends every
-`ssh`/`sftp` command and its full stderr to that file. The log holds no secrets — the password
-reaches `ssh` via `SSH_ASKPASS`, never the command line.
-
-## Port forwarding (`Ctrl-f` / `F4`)
-
-`Ctrl-f` on a host opens a small popup to start an SSH port forward that **keeps running in the
-background even after you quit sshelf**. Pick a kind (cycle with ←/→):
-
-- **Local** (`-L`, the default) — open a local port that tunnels to a host reachable from the
-  server (e.g. expose a remote DB at `127.0.0.1:8080`).
-- **Remote** (`-R`) — open a port *on the server* that tunnels back to a host reachable from here.
-- **Dynamic** (`-D`) — a local SOCKS proxy that routes through the server.
-
-Fill in the ports/host (defaults: bind `127.0.0.1`, target host `localhost`) and `Ctrl-s` to
-start. sshelf spawns a detached `ssh -N …`, reusing the host's auth exactly as connect does
-(keys/agent/ProxyJump or the stored password via `SSH_ASKPASS`, plus any site defaults), and
-waits briefly to confirm it bound — a failure (port already in use, a privileged `<1024` port,
-the server refusing a remote bind, or an auth failure) is shown in the popup so you can fix a
-field and retry. On success the TUI returns to the list and the tunnel runs on its own.
-
-`F4` opens the **forwards manager**: every active forward across all hosts, with its host, an
-`L`/`R`/`D` summary (`L  127.0.0.1:8080 → db:3306`), pid and age. `d` (or `k`) → `y` stops the
-selected one. The list refreshes live, so a forward that ends — stopped here, `kill`ed from
-another terminal, or dropped on its own (sleep / network) — disappears within a moment. Forwards
-**survive sshelf exiting** (each is a detached process in its own process group) and the ledger
-(`forwards.json`) is reconciled against the running processes on every launch, so you only ever
-see forwards that are still actually running. See [`decisions.md`](decisions.md) D-021.
-
-## Two-factor (2FA) hosts
-
-Some servers want an interactive verification code (TOTP / keyboard-interactive) on top of your
-key or password. Mark such a host with **2FA = yes** in the add/edit form (or `sshelf add …
---2fa`). On connect, sshelf shows a small popup to enter the current code **before** handing off
-to `ssh`, and supplies it to the verification prompt through the same askpass helper that supplies
-your stored password — sshelf never proxies the live session.
-
-The flag is needed because a connect that auto-supplies a stored secret runs `ssh` with
-`SSH_ASKPASS_REQUIRE=force`, which routes the code prompt to the helper with no terminal fallback —
-so without it the connect would simply fail. (A host with **no** stored secret already prompts for
-the code inline after handoff, so the flag mainly matters for stored-secret hosts; a host using an
-encrypted key with no stored passphrase should use an agent.) `sshelf <host>` from the CLI (no TUI)
-prompts for the code on the terminal instead. v1 is manual entry — sshelf does **not** store TOTP
-seeds. See [`decisions.md`](decisions.md) D-022.
-
-## CLI (outside the TUI)
-
-| Command | What it does |
-|---|---|
-| `sshelf` | Launch the interactive TUI. |
-| `sshelf <host>` | Connect straight to a saved host by **name or id**, skipping the TUI — same connect path as `Enter` (frecency recorded before the `exec`, secret auto-supplied). A miss suggests close names; a name that collides with a subcommand (`list`, `import`, …) is reached via the TUI instead. |
-| `sshelf -` | Reconnect to the most-recently-used host (max `last_used` in the frecency state). Errors (without connecting) if there's no history yet. |
-| `sshelf add` | With **no args**, opens the TUI add form. With **args**, adds a host non-interactively: `NAME` + `-H/--hostname` required; `-u/--user`, `-p/--port`, `-a/--auth`, `-i/--identity` (repeatable, implies key auth), `-J/--jump`, `-t/--tag`, `-s/--site`, `--extra "<flags>"`, `--password-stdin` (reads the secret from stdin). Duplicate names are refused. |
-| `sshelf sites [--json]` | List defined sites with member counts + their shared defaults. |
-| `sshelf sites add NAME [-u/-p/-J/-i]` | Define a site (settings optional; edit later with F3). |
-| `sshelf print-command <host>` | Print the generated, shell-quoted `ssh …` command for a saved host by **name or id** (reflecting any inherited site defaults), without connecting or changing frecency. CLI equivalent of the TUI's `Ctrl-y` yank. |
-| `sshelf list [query]` | List hosts (with a `·site·` column). `query` filters with the TUI's syntax — fuzzy text and/or `tag:NAME` / `site:NAME` (e.g. `sshelf list site:prod-dc`). |
-| `sshelf list --json [query]` | Same selection, emitted as JSON (each host's fields + its generated `command`). Always valid JSON, even when empty — the stable surface for scripts/integrations. |
-| `sshelf import [--dry-run]` | Read-only import from `~/.ssh/config`. |
-| `sshelf set-password <host>` | Store a password (read from stdin) for a host. |
-| `sshelf completions <shell>` · `sshelf man` | Emit static completions / the man page. |
-| `--config FILE` (global) | Use a specific config file (also `$SSHELF_CONFIG`). |
-| `--transfer-log FILE` (global) | Append transfer-screen diagnostics — the `ssh`/`sftp` commands and their errors (no secrets) — to `FILE`. Also `$SSHELF_TRANSFER_LOG`. |
-
-**Dynamic completion (host names):** static completions cover subcommands/flags only. Sourcing
-`COMPLETE=<shell> sshelf` (e.g. `source <(COMPLETE=zsh sshelf)`) enables host-name completion via
-clap_complete's engine — `host_name_candidates` reads `hosts.toml` (side-effect-free) and is
-attached to the `<host>` arguments of direct-connect, `print-command`, and `set-password`.
-
-## Confirmations & overlays
-
-- **Delete** pops a confirm modal (`y` = delete, any other key = cancel).
-- **Help** (`F1`) is an overlay listing all keys; any key closes it.
+Full-screen modes (transfer, sites, forwards manager) and popups (forward, 2FA, confirms)
+route keys **before** the list screen — first match wins — and render in the same precedence
+order, so input routing and drawing can't disagree. Destructive actions (delete a host, stop
+a forward) confirm with `y`; any other key cancels. Help (`F1`) is an overlay listing every
+key; any key closes it.
 
 ## Theming
 
-atuin-inspired defaults: dim chrome, a single accent color for selection + match highlights.
-Terminal resize is handled automatically by ratatui's layout — no manual recompute.
-
-## Configuration (`config.toml`)
-
-A commented default is written on first run. Keys:
-
-| Key | Default | Meaning |
-|---|---|---|
-| `decay_rate` | `0.2` | Frecency decay per day (higher = recency matters more). |
-| `default_sort` | `"frecency"` | Idle list order: `"frecency"` or `"name"`. |
-| `accent` | `"cyan"` | Accent color: black/red/green/yellow/blue/magenta/cyan/white/gray. |
-
-Location: `~/.config/sshelf/config.toml` (honors `XDG_CONFIG_HOME`).
+atuin-inspired defaults: dim chrome and a single accent color (config key `accent`) for the
+selection + match highlights. Terminal resize is handled by ratatui's layout pass — no manual
+recompute.


### PR DESCRIPTION
The site now opens with a Guide — install, quickstart, adding/editing hosts, searching & connecting, file transfer, port forwarding, sites & tags, passwords/keys/2FA, import, CLI reference, configuration, FAQ — built from content that previously lived in the README and ux.md. index.md becomes a product landing page, SUMMARY.md is reorganized into Guide / Understanding sshelf / Development, and ux.md slims down to UI design notes (stale milestone markers dropped).

The README shrinks to a landing page: pitch, install (secondary channels folded into a details block), a first-five-minutes section, badges, and links into the site. CONTRIBUTING's docs-in-sync rule now points user-facing changes at the Guide pages. Also fixes a stale TOC anchor in packaging.md. Docs only; no code changes.