### PR TITLE
feat: import hosts from a Tailscale tailnet (`sshelf import --tailscale`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ versions follow SemVer.
 
 ## [Unreleased]
 
-## [0.10.0] — 2026-07-13
+### Added
+- **`sshelf import --tailscale`** — import your Tailscale tailnet: every eligible machine
+  becomes a searchable sshelf host in one command. Runs **your own** `tailscale` CLI
+  (`tailscale status --json`) and maps each peer's MagicDNS name to the host name, its FQDN to
+  the hostname (stable across IP churn; the Tailscale IP when MagicDNS is off), your tailnet to
+  a [site](https://max-rh.github.io/sshelf/sites-tags.html), and its ACL tags to sshelf tags.
+  Mullvad exit nodes and machines shared in from other tailnets are left out, expired nodes are
+  skipped, and offline machines are imported (being asleep is temporary). **Add-only:** hosts
+  and sites that already exist are never touched, so re-running adds 0 — and, as ever, nothing
+  under `~/.ssh` is written. sshelf still makes no network calls of its own: the CLI runs only
+  when you type the command, never at startup or in the background. `$SSHELF_TAILSCALE_BIN`
+  points at the binary if it isn't on your `PATH` (the macOS app doesn't add it). No new
+  dependencies.
+
+### Changed
+- `sshelf import` now reports how many parsed hosts were skipped as duplicates, and prints any
+  site it creates.
 
 ## [0.10.0] — 2026-07-12
 
@@ -149,7 +165,6 @@ Initial public release.
   Linux).
 
 [Unreleased]: https://github.com/max-rh/sshelf/compare/v0.10.0...HEAD
-[0.10.0]: https://github.com/max-rh/sshelf/compare/v0.9.0...v0.10.0
 [0.10.0]: https://github.com/max-rh/sshelf/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/max-rh/sshelf/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/max-rh/sshelf/compare/v0.7.0...v0.8.0

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ editor — and it adds what plain SSH config can't express:
 - **2FA hosts** — flag a host and sshelf prompts for the verification code on connect.
 - **SSH-config export** — one generated `Include` file, and plain `ssh`/`scp`/`rsync` — and
   anything that reads SSH config, like VS Code Remote — sees your sshelf hosts by name.
+- **Tailscale import** — `sshelf import --tailscale` turns your whole tailnet into searchable
+  hosts (MagicDNS names, tailnet as a site, ACL tags as tags), by running your own `tailscale`
+  CLI. Add-only, so re-running is safe.
 - **Jump hosts, a guided add/edit form, frecency ordering, read-only import** from `~/.ssh/config`.
 
 **Never:** no telemetry, no account, no cloud — and it will never edit your SSH config.
@@ -94,6 +97,7 @@ Full details + completions setup: **[Install guide](https://max-rh.github.io/ssh
 sshelf                        # launch the TUI — Ctrl-a adds your first host
 sshelf import --dry-run       # preview a read-only import from ~/.ssh/config
 sshelf import                 # …do it
+sshelf import --tailscale     # …or import your whole Tailscale tailnet
 sshelf prod-web               # connect straight to a saved host (skips the TUI)
 sshelf -                      # reconnect to the most recently used host
 sshelf list tag:prod --json   # scriptable listing (fields + generated command)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -12,7 +12,7 @@
 - [Port forwarding](port-forwarding.md)
 - [Sites & tags](sites-tags.md)
 - [Passwords, keys & 2FA](passwords-2fa.md)
-- [Importing from ~/.ssh/config](import.md)
+- [Importing hosts](import.md)
 - [Exporting to SSH config](export.md)
 - [CLI reference](cli.md)
 - [Configuration](configuration.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,7 +62,8 @@
   [`security.md`](./security.md).
 
 - **Own database, never `~/.ssh/config`.** Hosts live in `hosts.toml` (human-readable, atomic
-  writes). Import from `~/.ssh/config` is read-only. See [`data-model.md`](./data-model.md).
+  writes). Importers (`~/.ssh/config`, a Tailscale tailnet) are read-only towards their source
+  and add-only towards the database. See [`data-model.md`](./data-model.md).
 
 - **Synchronous event loop, component pattern.** No background work needs multiplexing (the
   one long-running thing, the SSH session, happens *after* the TUI is gone). A simple

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,7 @@ Everything sshelf does without opening the TUI.
 | `sshelf sites [--json]` | List defined sites with member counts + their shared defaults. |
 | `sshelf sites add NAME [-u/-p/-J/-i]` | Define a [site](sites-tags.md) (settings optional; edit later with `F3`). |
 | `sshelf import [--dry-run]` | [Read-only import](import.md) from `~/.ssh/config`. |
+| `sshelf import --tailscale [--dry-run]` | [Import your Tailscale tailnet](import.md#from-tailscale): runs your own `tailscale status --json` and adds every eligible peer (MagicDNS name → host, tailnet → site, ACL tags → tags). Add-only; re-running adds 0. |
 | `sshelf export [--stdout]` | [Export](export.md) the database as an ssh_config `Include` fragment, written next to sshelf's config (`--stdout` prints it instead). Once the file exists, it refreshes on every hosts change. |
 | `sshelf set-password <host>` | Store a password / key passphrase for a host, read from **stdin**. |
 | `sshelf completions <shell>` | Print static shell completions. |
@@ -24,6 +25,12 @@ Global flags: **`--config FILE`** — use a specific config file (also `$SSHELF_
 [Configuration](configuration.md). **`--transfer-log FILE`** — append transfer diagnostics,
 no secrets, to FILE (also `$SSHELF_TRANSFER_LOG`); see
 [Transferring files](transfer.md#debugging-a-failing-transfer).
+
+Environment: **`$SSHELF_TAILSCALE_BIN`** — the `tailscale` binary `--tailscale` should run,
+for installs that aren't on `PATH` (sshelf otherwise tries `PATH`, then the macOS app bundle
+at `/Applications/Tailscale.app/Contents/MacOS/Tailscale`). **`$SSHELF_VAULT_PASSPHRASE`** —
+use the `age` vault instead of the OS keyring; see
+[Passwords, keys & 2FA](passwords-2fa.md#where-secrets-live).
 
 ## Adding hosts from the CLI
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,6 +5,36 @@ whenever you make a non-trivial design choice.
 
 ---
 
+### D-024 · Tailscale import shells out to the user's CLI; MagicDNS names, suffix eligibility, add-only
+`sshelf import --tailscale` fills the database from a tailnet — the inventory a homelab/small-fleet
+user already curates — without sshelf growing a network client. It **shells out to the user's own
+`tailscale status --json`** and parses stdout. Rejected: the Tailscale HTTP API / an SDK, which
+would mean an API key to store (violating the no-secrets-in-`hosts.toml` rule and the whole
+secret-handling story), an HTTP + async dependency stack, and sshelf making network calls of its
+own; and reading `tailscaled`'s local socket directly (unstable, root-ish, platform-specific).
+Shelling out keeps the **no-network posture intact**: the binary runs only when the user runs the
+subcommand — never at startup, on save, on a timer, or from the TUI. Binary resolution is
+`$SSHELF_TAILSCALE_BIN` → `PATH` → `/Applications/Tailscale.app/Contents/MacOS/Tailscale`,
+because the macOS app doesn't put its CLI on `PATH`.
+
+**`hostname` = the MagicDNS FQDN**, not a Tailscale IP: it survives IP churn, reads better in the
+list, and is what Tailscale SSH expects — with the IP (IPv4 first) as the fallback when MagicDNS
+is disabled for the tailnet. **Eligibility is one rule: the peer's `DNSName` must sit under the
+tailnet's own `MagicDNSSuffix`** — which excludes Mullvad exit nodes and shared-in/foreign nodes
+without special-casing either. Rejected: filtering by `ExitNodeOption`/`OS`/owner (a list of
+special cases that ages badly). Expired peers are skipped; **offline peers are not** — `Online`
+is transient and an asleep laptop is still a real host. The tailnet becomes a **site** (matched
+case-insensitively, created bare when new) and ACL tags become sshelf tags minus the `tag:`
+prefix, so the tailnet's own structure carries over instead of being flattened.
+
+Import is **add-only**: existing hosts and sites are never updated or deleted, so re-running
+converges to "0 added" and the user's own edits (a `user`, a port, a password) are never
+clobbered. Rejected: sync semantics (two-way reconciliation, deletion of departed nodes) — that
+needs a per-host record of provenance, and v1 deliberately stores **nothing** tailscale-specific
+in `hosts.toml`: no node IDs, no keys. The JSON→hosts mapping is a pure function over `&str`
+(mirroring `import::parse_str`), so the whole feature is fixture-tested without the binary,
+a tailnet, or a network.
+
 ### D-023 · Export writes our own ssh_config fragment; the user adds the Include line
 `sshelf export` projects the database into ssh_config format so native tools (ssh/scp/sftp,
 rsync, git, editor remote extensions) resolve sshelf hosts by name — the standing objection to

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,6 +22,15 @@ with anything reasonably modern. Platforms: macOS + Linux, x86_64 and arm64.
 No. No telemetry, no account, no network calls of its own — the only network activity is the
 `ssh`/`sftp` it runs for you. See [Security](security.md).
 
+## Then how does the Tailscale import work?
+
+The same way: by running a program you already have.
+[`sshelf import --tailscale`](import.md#from-tailscale) executes **your** `tailscale` CLI
+(`tailscale status --json`) and parses its output — sshelf opens no sockets, holds no API key,
+and talks to no Tailscale server. It only ever runs when you type that command: never at
+startup, on a save, on a timer, or from the TUI. Nothing tailscale-specific (node IDs, keys) is
+written to `hosts.toml`, and the import only ever *adds* hosts.
+
 ## Password auto-supply isn't working
 
 - Check `ssh -V` — you need OpenSSH 8.4+ (see above).

--- a/docs/import.md
+++ b/docs/import.md
@@ -1,4 +1,10 @@
-# Importing from ~/.ssh/config
+# Importing hosts
+
+sshelf can populate its database from two sources you already have: your **SSH config** and
+your **Tailscale tailnet**. Both are read-only towards their source and **add-only** towards
+sshelf — a host whose name already exists is left alone, so re-running is always safe.
+
+## From `~/.ssh/config`
 
 `sshelf import` (or `Ctrl-o` in the TUI) copies hosts from `~/.ssh/config` into sshelf's own
 database. It is **strictly read-only**: sshelf parses the file and never writes back — your
@@ -17,10 +23,58 @@ What it does:
 - **warns** about directives it doesn't import — `Match`, `Include`, `ProxyJump` — instead of
   silently mis-importing them.
 
+## From Tailscale
+
+`sshelf import --tailscale` imports your **tailnet** — every machine in it becomes a
+searchable sshelf host, in one command.
+
+```sh
+sshelf import --tailscale --dry-run   # preview
+sshelf import --tailscale             # import
+```
+
+It runs **your own** `tailscale` CLI (`tailscale status --json`) and reads the output. sshelf
+still makes no network calls of its own: nothing happens unless you run this command — never
+at startup, never on a save, never in the background, and there's no Tailscale entry point in
+the TUI. Your API keys and tailnet credentials stay with the Tailscale client; sshelf never
+sees them, and nothing tailscale-specific is written to `hosts.toml`.
+
+**Which machines are imported.** Every peer whose MagicDNS name is under your tailnet's own
+domain — one rule that leaves out Mullvad exit nodes and machines shared in from other
+tailnets. Peers with an **expired** node key are skipped. **Offline peers are imported**: being
+asleep is temporary, and the host is still real. This machine (`Self`) is not imported.
+
+**What each machine becomes:**
+
+| sshelf field | From the peer |
+|---|---|
+| `name` | First label of the MagicDNS name, lowercased (e.g. `nas.tail4f9a2.ts.net.` → `nas`). |
+| `hostname` | The MagicDNS FQDN (`nas.tail4f9a2.ts.net`) — stable across IP churn, and what Tailscale SSH expects. If MagicDNS is off for your tailnet, its Tailscale IP (IPv4 first). |
+| `site` | Your tailnet's name — matched to an existing [site](sites-tags.md) case-insensitively, or created as a bare one (name only, no defaults). |
+| `tags` | The machine's ACL tags, minus the `tag:` prefix (`tag:server` → `server`). Untagged machines get no tags. |
+| `auth` | `agent` — your key/agent auth, unchanged. Add a user, port or password afterwards if a box needs one. |
+
+Two machines whose names collide (possible only across sub-domains) keep the first; the second
+is reported. Everything skipped is counted in a warning line, so the numbers always add up.
+
+**If sshelf can't find the CLI.** It looks at `$SSHELF_TAILSCALE_BIN`, then `tailscale` on your
+`PATH`, then `/Applications/Tailscale.app/Contents/MacOS/Tailscale` — the macOS app doesn't put
+its CLI on `PATH`. For any other location:
+
+```sh
+SSHELF_TAILSCALE_BIN=/path/to/tailscale sshelf import --tailscale
+```
+
+The import needs the Tailscale backend to be **running** (`tailscale up`); if it isn't, sshelf
+says so and changes nothing.
+
+## After importing
+
 Import brings everything in at once (there's no per-host picker); curate afterwards with
 `Ctrl-e` / `Ctrl-d`, and organize with tags or [sites](sites-tags.md). Your `~/.ssh/config`
 keeps working exactly as before — sshelf's database is independent of it by design (the
 [FAQ](faq.md#why-doesnt-sshelf-just-use-my-ssh-config) explains why).
 
 The reverse direction exists too: [**export**](export.md) projects your sshelf hosts back out
-as an `Include` fragment, so plain `ssh`/`scp` can use them by name.
+as an `Include` fragment, so plain `ssh`/`scp` can use them by name — including everything a
+tailnet import just added.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ sshelf                             # launch the TUI
   [Passwords, keys & 2FA](passwords-2fa.md)
 - **SSH-config export** — one `Include` line and plain `ssh`/`scp`, rsync, and VS Code Remote
   see your hosts — [Exporting to SSH config](export.md)
+- **Import** from `~/.ssh/config` or your whole **Tailscale tailnet** (`--tailscale`) —
+  [Importing hosts](import.md)
 - A scriptable **CLI** (`sshelf add`, `list --json`, `print-command`, …) — [CLI reference](cli.md)
 
 Platforms: **macOS + Linux**, x86_64 and arm64. Runtime: **OpenSSH 8.4+** for password

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -3,8 +3,45 @@
 Reverse-chronological. Newest entry on top. Every change to the project adds an entry here
 (the docs-in-sync rule). Keep entries short: what changed, why, and what's next.
 
-**Current milestone:** Interop — `sshelf export` projects the database out to plain ssh via an
-`Include` fragment. Targets v0.10.0. (Docs overhaul + v0.9.0 distribution shipped.)
+**Current milestone:** Inventory import — `sshelf import --tailscale` fills the database from a
+tailnet. Targets v0.11.0. (v0.10.0 export shipped.)
+
+---
+
+## 2026-07-27 — `sshelf import --tailscale`: the tailnet as an inventory source
+
+- New `tailscale.rs` + a `--tailscale` flag on `import`: runs the **user's own** `tailscale
+  status --json` and maps every eligible peer to a host — MagicDNS first label → `name`, the
+  MagicDNS FQDN → `hostname` (Tailscale IP, IPv4 first, when MagicDNS is off for the tailnet),
+  the tailnet → a `site`, ACL tags minus the `tag:` prefix → `tags`, auth `agent`. Eligibility
+  is one rule — the peer's `DNSName` must sit under the tailnet's own `MagicDNSSuffix` — which
+  drops Mullvad exit nodes and shared-in nodes without special cases; expired peers are
+  skipped, offline ones are **not** (an asleep laptop is still a host). Binary resolution:
+  `$SSHELF_TAILSCALE_BIN` → `PATH` → the macOS app bundle, with an error that names all three.
+- **Add-only, in both directions:** existing hosts and sites are never updated or deleted
+  (case-insensitive match), so a re-run converges to "0 added" and a byte-identical
+  `hosts.toml`. Nothing tailscale-specific (node IDs, keys) is stored. The no-network posture
+  stands — the CLI runs only from this subcommand, never at startup, on save, on a timer, or
+  from the TUI. Rationale + rejected alternatives: **D-024**.
+- Refactor: both import modes now share one tail (`apply_import`) — dedupe, site creation
+  (`import::missing_sites`), save, export refresh — so the D-023 fragment auto-refreshes after
+  a tailnet import exactly as it does after an ssh-config one. The summary gained a
+  duplicates count and a line per created site.
+- **Verified end-to-end** against a stub `tailscale` fed the test fixture, with an isolated
+  config dir: 3 hosts + the site land in `hosts.toml`, counts match (3 parsed, 3 excluded — 2
+  foreign, 1 expired), a second run adds 0 with an identical file, `--dry-run` writes nothing,
+  and an existing `NAS` host + differently-cased site are reused, not duplicated. A
+  pre-created export fragment refreshed to the imported hosts; without one, nothing was
+  created. Each failure mode gives one message and exit 1: backend not running, unparseable
+  JSON, a bogus `$SSHELF_TAILSCALE_BIN`. The macOS app-bundle fallback was exercised against
+  the **real** client (which reported `NeedsLogin` → the friendly "run `tailscale up`" error);
+  no logged-in tailnet on this machine, so a live import is still unverified. `~/.ssh` was
+  byte-identical throughout, and the ssh-config import path was re-checked through the shared
+  tail. 18 new tests (213 pass), clippy + `fmt --check` clean.
+- Docs synced: `import.md` (now "Importing hosts", with the mapping table and the opt-in/
+  no-network posture), cli reference (flag + `$SSHELF_TAILSCALE_BIN`), FAQ, structure, index,
+  README, CHANGELOG (also collapsed a duplicated `0.10.0` heading + link line). Ships in
+  **v0.11.0** via `feat/import-tailscale`. Next: `--hcloud`/`--aws` only if demand shows up.
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -33,11 +33,16 @@ tailnet. Targets v0.11.0. (v0.10.0 export shipped.)
   and an existing `NAS` host + differently-cased site are reused, not duplicated. A
   pre-created export fragment refreshed to the imported hosts; without one, nothing was
   created. Each failure mode gives one message and exit 1: backend not running, unparseable
-  JSON, a bogus `$SSHELF_TAILSCALE_BIN`. The macOS app-bundle fallback was exercised against
-  the **real** client (which reported `NeedsLogin` → the friendly "run `tailscale up`" error);
-  no logged-in tailnet on this machine, so a live import is still unverified. `~/.ssh` was
-  byte-identical throughout, and the ssh-config import path was re-checked through the shared
-  tail. 18 new tests (213 pass), clippy + `fmt --check` clean.
+  JSON, a bogus `$SSHELF_TAILSCALE_BIN`. `~/.ssh` was byte-identical throughout (content
+  hashes, not a directory listing), and the ssh-config import path was re-checked through the
+  shared tail. 18 new tests (213 pass), clippy + `fmt --check` clean.
+- **Live tailnet run:** on a real 6-peer tailnet — MagicDNS **disabled**, so the IPv4 fallback
+  took the real path — the binary resolved itself from the macOS app bundle and imported the 2
+  peers with valid node keys (`100.x` addresses, site from `CurrentTailnet.Name`), excluding 4
+  with expired keys and this machine (`Self`); a re-run added 0, and `list --json` /
+  `print-command` produced usable `ssh` commands. Earlier, before login, the same client
+  reported `NeedsLogin` → the friendly "run `tailscale up`" error, so both live states are
+  covered.
 - Docs synced: `import.md` (now "Importing hosts", with the mapping table and the opt-in/
   no-network posture), cli reference (flag + `$SSHELF_TAILSCALE_BIN`), FAQ, structure, index,
   README, CHANGELOG (also collapsed a duplicated `0.10.0` heading + link line). Ships in

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,6 +25,9 @@ sshelf import --dry-run    # preview what would be imported
 sshelf import              # do it (or press Ctrl-o in the TUI)
 ```
 
+On a **Tailscale** tailnet, `sshelf import --tailscale` brings in every machine in one go —
+same rules, [same read-only, add-only promise](import.md#from-tailscale).
+
 ## 3. Connect
 
 Type a few characters to fuzzy-filter, `Enter` to connect. sshelf records your usage and then

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -2,9 +2,9 @@
 
 > Keep this in sync with the actual tree (the docs-in-sync rule).
 >
-> **All modules present:** `main`, `app`, `askpass`, `config`, `forwards`, `import`, `model`,
-> `paths`, `search`, `secrets`, `ssh`, `state`, `store`, `transfer/{mod,worker,pane,screen,e2e}`,
-> `testsupport` (test-only), `vault`,
+> **All modules present:** `main`, `app`, `askpass`, `config`, `export`, `forwards`, `import`,
+> `model`, `paths`, `search`, `secrets`, `ssh`, `state`, `store`, `tailscale`,
+> `transfer/{mod,worker,pane,screen,e2e}`, `testsupport` (test-only), `vault`,
 > `ui/{mod,list,help,widgets,wizard,browse,settings,sites,transfer,forward_popup,forwards,two_factor}`.
 > (`error.rs` was removed — the codebase uses `anyhow` throughout.)
 
@@ -36,7 +36,8 @@ ssh-tui/                 (crate/binary name: `sshelf`)
 | `ssh.rs` | Build `ssh` argv from a `Host`; terminal teardown + `exec()` handoff; askpass env wiring. |
 | `askpass.rs` | Headless askpass entry: inspect `argv[1]`; answer password prompts via `secrets`, or a queued 2FA code (`SSHELF_2FA_CODE`) for the verification prompt; else decline. |
 | `search.rs` | Fuzzy filter (`nucleo-matcher`) + frecency ranking + per-row match indices for highlight. |
-| `import.rs` | `ssh2-config` parse of `~/.ssh/config` → `Host` mapping; warn on unsupported `Match`/`Include`. |
+| `import.rs` | `ssh2-config` parse of `~/.ssh/config` → `Host` mapping; warn on unsupported `Match`/`Include`. Also the shape (`ImportResult`) and add-only plumbing (`new_hosts`, `missing_sites`) every importer shares. |
+| `tailscale.rs` | `sshelf import --tailscale`: locate the user's `tailscale` binary, run `status --json`, map eligible peers → hosts (MagicDNS name/FQDN, tailnet → site, ACL tags). Pure parser over `&str`; the only process spawn is isolated in one function. |
 | `export.rs` | Render the database as an ssh_config `Include` fragment (site defaults resolved, `-o` extras translated); write to `ssh_config` in the config dir; auto-refresh on hosts saves once the file exists. |
 | `paths.rs` | `etcetera` path resolution (config/data dirs); file paths; dir/file perms (`0700`/`0600`). |
 | `config.rs` | Preferences: `decay_rate`, `default_sort`, `accent` color; writes a commented default on first run. |

--- a/src/import.rs
+++ b/src/import.rs
@@ -12,8 +12,11 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use ssh2_config::{ParseRule, SshConfig};
 
-use crate::model::{AuthMethod, Host};
+use crate::model::{AuthMethod, Host, Site, find_site};
 
+/// What an importer produces, whatever its source (`~/.ssh/config`, a tailnet, …): the hosts
+/// it mapped, plus what it couldn't map and wants the user to know about.
+#[derive(Debug)]
 pub struct ImportResult {
     pub hosts: Vec<Host>,
     pub warnings: Vec<String>,
@@ -73,6 +76,27 @@ pub fn new_hosts<'a>(parsed: &'a [Host], existing: &[Host]) -> Vec<&'a Host> {
         .iter()
         .filter(|h| !names.contains(&h.name.to_lowercase()))
         .collect()
+}
+
+/// Add-only site handling for imports: point each host at the **existing** spelling of the
+/// site it names (matched case-insensitively) and return the bare sites that still need
+/// creating. Existing sites are never modified — only referenced.
+pub fn missing_sites(hosts: &mut [Host], existing: &[Site]) -> Vec<Site> {
+    let mut fresh: Vec<Site> = Vec::new();
+    for host in hosts.iter_mut() {
+        let Some(name) = host.site.clone() else {
+            continue;
+        };
+        // Clone the matched spelling before touching `fresh` again (it may be borrowed from it).
+        let known = find_site(existing, &name)
+            .or_else(|| find_site(&fresh, &name))
+            .map(|site| site.name.clone());
+        match known {
+            Some(spelling) => host.site = Some(spelling),
+            None => fresh.push(Site::new(name)),
+        }
+    }
+    fresh
 }
 
 fn is_wildcard(pat: &str) -> bool {
@@ -166,6 +190,31 @@ Host behind
     fn warns_about_proxyjump() {
         let r = parse_str(SAMPLE).unwrap();
         assert!(r.warnings.iter().any(|w| w.contains("ProxyJump")));
+    }
+
+    #[test]
+    fn missing_sites_matches_case_insensitively_and_creates_once() {
+        let mut hosts = vec![
+            Host::new("a", "h1"),
+            Host::new("b", "h2"),
+            Host::new("c", "h3"),
+            Host::new("d", "h4"),
+        ];
+        hosts[0].site = Some("TAILNET".into()); // existing, differently cased
+        hosts[1].site = Some("new-net".into()); // to be created
+        hosts[2].site = Some("New-Net".into()); // same new site, differently cased
+        // hosts[3] has no site at all
+
+        let existing = vec![Site::new("Tailnet")];
+        let fresh = missing_sites(&mut hosts, &existing);
+
+        // The existing site is reused with its own spelling, never redefined.
+        assert_eq!(hosts[0].site.as_deref(), Some("Tailnet"));
+        assert_eq!(fresh.len(), 1);
+        assert_eq!(fresh[0], Site::new("new-net")); // bare: name only, no defaults
+        assert_eq!(hosts[1].site.as_deref(), Some("new-net"));
+        assert_eq!(hosts[2].site.as_deref(), Some("new-net"));
+        assert_eq!(hosts[3].site, None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod secrets;
 mod ssh;
 mod state;
 mod store;
+mod tailscale;
 #[cfg(test)]
 mod testsupport;
 mod transfer;
@@ -75,11 +76,16 @@ enum Command {
     /// Add a host. With no arguments, opens the TUI add form; with arguments, adds it
     /// non-interactively (NAME and --hostname are required).
     Add(AddArgs),
-    /// Import hosts from ~/.ssh/config (read-only).
+    /// Import hosts from ~/.ssh/config (read-only), or from your Tailscale tailnet.
     Import {
         /// Show what would be imported without writing.
         #[arg(long)]
         dry_run: bool,
+        /// Import your Tailscale tailnet instead of ~/.ssh/config: runs your own
+        /// `tailscale status --json` and adds every eligible peer. Set $SSHELF_TAILSCALE_BIN
+        /// if the CLI isn't on your PATH.
+        #[arg(long)]
+        tailscale: bool,
     },
     /// Export hosts as an ssh_config fragment, written next to sshelf's config. Add one
     /// `Include` line to ~/.ssh/config yourself (sshelf never edits it) and plain ssh/scp/sftp
@@ -294,7 +300,7 @@ fn main() -> Result<()> {
                 app::run_add()
             }
         }
-        Some(Command::Import { dry_run }) => cmd_import(dry_run),
+        Some(Command::Import { dry_run, tailscale }) => cmd_import(dry_run, tailscale),
         Some(Command::Export { stdout }) => cmd_export(stdout),
         Some(Command::SetPassword { host }) => cmd_set_password(&host),
         Some(Command::Print { host }) => cmd_print_command(&host),
@@ -316,17 +322,37 @@ fn main() -> Result<()> {
     }
 }
 
-fn cmd_import(dry_run: bool) -> Result<()> {
-    let path = import::default_config_path().context("HOME is not set")?;
-    if !path.exists() {
-        anyhow::bail!("no ssh config at {}", path.display());
-    }
-    let result = import::parse_file(&path)?;
-    println!(
-        "Parsed {} host(s) from {}",
-        result.hosts.len(),
-        path.display()
-    );
+/// `sshelf import` — from `~/.ssh/config` by default, or from the user's Tailscale tailnet
+/// with `--tailscale`. Both sources are read-only and both are **add-only** toward
+/// `hosts.toml`: a re-run converges to "0 added".
+fn cmd_import(dry_run: bool, tailscale: bool) -> Result<()> {
+    let result = if tailscale {
+        let result = tailscale::import_tailnet()?;
+        println!(
+            "Parsed {} host(s) from your Tailscale tailnet",
+            result.hosts.len()
+        );
+        result
+    } else {
+        let path = import::default_config_path().context("HOME is not set")?;
+        if !path.exists() {
+            anyhow::bail!("no ssh config at {}", path.display());
+        }
+        let result = import::parse_file(&path)?;
+        println!(
+            "Parsed {} host(s) from {}",
+            result.hosts.len(),
+            path.display()
+        );
+        result
+    };
+    apply_import(result, dry_run)
+}
+
+/// The shared tail of every import mode: report warnings, skip names that already exist
+/// (case-insensitively — never update or delete one), create any site the parsed hosts
+/// reference, persist, and refresh the exported ssh_config fragment.
+fn apply_import(result: import::ImportResult, dry_run: bool) -> Result<()> {
     for w in &result.warnings {
         println!("  warning: {w}");
     }
@@ -336,27 +362,46 @@ fn cmd_import(dry_run: bool) -> Result<()> {
     let cfg = Config::load(&paths.config_file())?;
     let hosts_path = cfg.hosts_path(&paths);
     let mut file = store::load_hosts(&hosts_path)?;
-    let to_add = import::new_hosts(&result.hosts, &file.hosts)
+    let mut to_add = import::new_hosts(&result.hosts, &file.hosts)
         .into_iter()
         .cloned()
         .collect::<Vec<_>>();
+    let duplicates = result.hosts.len() - to_add.len();
 
     if to_add.is_empty() {
-        println!("Nothing new to import (all names already exist).");
+        if duplicates == 0 {
+            println!("Nothing to import.");
+        } else {
+            println!("0 added — {duplicates} name(s) already exist in sshelf.");
+        }
         return Ok(());
     }
+    let new_sites = import::missing_sites(&mut to_add, &file.sites);
+
     println!("{} new host(s):", to_add.len());
     for h in &to_add {
         println!("  {:<20} {}", h.name, h.endpoint());
+    }
+    for s in &new_sites {
+        println!("  + site '{}'", s.name);
     }
     if dry_run {
         println!("(dry run — nothing written)");
         return Ok(());
     }
+    let added = to_add.len();
+    file.sites.extend(new_sites);
     file.hosts.extend(to_add);
     store::save_hosts(&hosts_path, &file)?;
     warn_export_refresh(export::refresh_if_exported(&paths, &file));
-    println!("Imported into {}", hosts_path.display());
+    let skipped = match duplicates {
+        0 => String::new(),
+        n => format!(" ({n} skipped as duplicates)"),
+    };
+    println!(
+        "Imported {added} host(s) into {}{skipped}",
+        hosts_path.display()
+    );
     Ok(())
 }
 
@@ -878,6 +923,26 @@ mod tests {
             Some(Command::Print { host }) => assert_eq!(host, "prod-web"),
             _ => panic!("expected the print-command subcommand"),
         }
+    }
+
+    #[test]
+    fn import_defaults_to_ssh_config_and_opts_into_tailscale() {
+        let c = Cli::try_parse_from(["sshelf", "import"]).unwrap();
+        assert!(matches!(
+            c.command,
+            Some(Command::Import {
+                dry_run: false,
+                tailscale: false
+            })
+        ));
+        let c = Cli::try_parse_from(["sshelf", "import", "--tailscale", "--dry-run"]).unwrap();
+        assert!(matches!(
+            c.command,
+            Some(Command::Import {
+                dry_run: true,
+                tailscale: true
+            })
+        ));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -48,7 +48,7 @@ pub struct Site {
 }
 
 impl Site {
-    #[allow(dead_code)] // wired into the sites manager + `sshelf sites add` (M3/M4)
+    /// A bare site: name only, no shared defaults (what an import creates).
     pub fn new(name: impl Into<String>) -> Self {
         Site {
             name: name.into(),

--- a/src/tailscale.rs
+++ b/src/tailscale.rs
@@ -1,0 +1,650 @@
+//! Opt-in inventory import from the user's own Tailscale tailnet.
+//!
+//! `sshelf import --tailscale` shells out to the **user's** `tailscale` CLI
+//! (`tailscale status --json`) and maps every eligible peer to a host. sshelf still opens no
+//! sockets of its own: the binary is run only by that subcommand — never at startup, on save,
+//! on a timer, or from the TUI (see `docs/decisions.md` D-024).
+//!
+//! Everything except [`capture_status`] is pure and unit-tested against fixture JSON, so the
+//! tests need neither a tailscale binary nor a network.
+
+use std::collections::{BTreeMap, HashSet};
+use std::ffi::OsStr;
+use std::net::Ipv4Addr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+use crate::import::ImportResult;
+use crate::model::Host;
+
+/// Override for the `tailscale` binary — nonstandard installs, and the test seam.
+pub const BIN_ENV: &str = "SSHELF_TAILSCALE_BIN";
+
+/// The macOS app bundle ships the CLI here and doesn't put it on `PATH`.
+const MACOS_APP_BIN: &str = "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
+
+/// The slice of tailscale's `ipn/ipnstate.Status` we read. Unknown fields are ignored, so a
+/// newer client only breaks us if it renames one of these.
+#[derive(Debug, Deserialize)]
+struct Status {
+    #[serde(rename = "BackendState", default)]
+    backend_state: String,
+    #[serde(rename = "CurrentTailnet", default)]
+    current_tailnet: Option<Tailnet>,
+    /// Keyed by node public key. A `BTreeMap` keeps iteration (and therefore
+    /// first-wins collision handling) deterministic.
+    #[serde(rename = "Peer", default)]
+    peer: Option<BTreeMap<String, PeerStatus>>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Tailnet {
+    #[serde(rename = "Name", default)]
+    name: String,
+    #[serde(rename = "MagicDNSSuffix", default)]
+    magic_dns_suffix: String,
+    #[serde(rename = "MagicDNSEnabled", default)]
+    magic_dns_enabled: bool,
+}
+
+/// One peer (`ipnstate.PeerStatus`). `Tags` and `Expired` are omitted when unset; the IP
+/// lists are `null` rather than absent on a node that has none — hence the `Option`s.
+#[derive(Debug, Deserialize)]
+struct PeerStatus {
+    #[serde(rename = "HostName", default)]
+    host_name: String,
+    /// The MagicDNS FQDN, with a trailing dot.
+    #[serde(rename = "DNSName", default)]
+    dns_name: String,
+    #[serde(rename = "TailscaleIPs", default)]
+    tailscale_ips: Option<Vec<String>>,
+    /// ACL tags, each prefixed `tag:`.
+    #[serde(rename = "Tags", default)]
+    tags: Option<Vec<String>>,
+    #[serde(rename = "Expired", default)]
+    expired: Option<bool>,
+}
+
+/// Resolve the user's `tailscale` binary, run `status --json`, and map the tailnet to hosts.
+/// The one impure entry point of this module.
+pub fn import_tailnet() -> Result<ImportResult> {
+    let bin = resolve_binary()?;
+    let json = capture_status(&bin)?;
+    parse_status_json(&json)
+}
+
+/// Map `tailscale status --json` output to hosts. Pure: no process, no file, no socket.
+///
+/// A peer is imported when its `DNSName` sits under the tailnet's own `MagicDNSSuffix` —
+/// one rule that excludes Mullvad exit nodes and foreign/shared-in nodes alike. Expired peers
+/// are skipped; **offline peers are not** (`Online` is transient — an asleep laptop is still a
+/// real host). `Self` isn't in the peer map, so it's never imported.
+pub fn parse_status_json(text: &str) -> Result<ImportResult> {
+    let status: Status = serde_json::from_str(text).context(
+        "could not parse the output of `tailscale status --json` — a tailscale client much \
+         newer or older than this build is the likely cause (check `tailscale version`)",
+    )?;
+
+    if status.backend_state != "Running" {
+        let state = match status.backend_state.as_str() {
+            "" => "unknown",
+            s => s,
+        };
+        bail!(
+            "tailscale isn't running (backend state: {state}) — run `tailscale up` (or start \
+             the Tailscale app), then try the import again"
+        );
+    }
+
+    let tailnet = status.current_tailnet.unwrap_or_default();
+    // Compare suffixes case-insensitively and without the trailing dot of an FQDN.
+    let suffix = tailnet.magic_dns_suffix.trim_matches('.').to_lowercase();
+    if suffix.is_empty() {
+        bail!(
+            "`tailscale status --json` reported no tailnet (CurrentTailnet.MagicDNSSuffix is \
+             empty) — check `tailscale status` and make sure this machine is fully logged in"
+        );
+    }
+    let site = if tailnet.name.is_empty() {
+        first_label(&suffix).to_string()
+    } else {
+        tailnet.name.clone()
+    };
+
+    let mut hosts: Vec<Host> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let (mut foreign, mut expired, mut unusable) = (0usize, 0usize, 0usize);
+
+    for peer in status.peer.unwrap_or_default().values() {
+        if peer.expired.unwrap_or(false) {
+            expired += 1;
+            continue;
+        }
+        let dns = peer.dns_name.trim().trim_end_matches('.');
+        // An empty DNSName can't be checked against the suffix — but it also can't belong to
+        // another tailnet (those always carry their own FQDN), so it falls back to HostName/IP.
+        if !dns.is_empty() && !dns.to_lowercase().ends_with(&format!(".{suffix}")) {
+            foreign += 1;
+            continue;
+        }
+        let ips = peer.tailscale_ips.as_deref().unwrap_or_default();
+        let (Some(name), Some(hostname)) = (
+            peer_name(dns, &peer.host_name),
+            peer_hostname(dns, ips, tailnet.magic_dns_enabled),
+        ) else {
+            unusable += 1;
+            continue;
+        };
+        if !seen.insert(name.clone()) {
+            warnings.push(format!(
+                "two peers map to the name {name:?} — kept the first, skipped the other"
+            ));
+            continue;
+        }
+        let mut host = Host::new(name, hostname);
+        host.site = Some(site.clone());
+        host.tags = peer_tags(peer.tags.as_deref().unwrap_or_default());
+        hosts.push(host);
+    }
+    // MagicDNS names are unique inside a tailnet, so this is a stable, tidy order.
+    hosts.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let excluded = foreign + expired + unusable;
+    if excluded > 0 {
+        let mut parts = Vec::new();
+        if foreign > 0 {
+            parts.push(format!("{foreign} outside this tailnet"));
+        }
+        if expired > 0 {
+            parts.push(format!("{expired} with an expired node key"));
+        }
+        if unusable > 0 {
+            parts.push(format!("{unusable} with no usable name or address"));
+        }
+        warnings.insert(
+            0,
+            format!("{excluded} peer(s) excluded ({})", parts.join(", ")),
+        );
+    }
+    Ok(ImportResult { hosts, warnings })
+}
+
+/// The host alias: the first label of the MagicDNS name (unique within a tailnet), or the
+/// peer's `HostName` when it has no DNS name. Lowercased; `None` when both are empty.
+fn peer_name(dns: &str, host_name: &str) -> Option<String> {
+    let from_dns = first_label(dns).trim();
+    let name = if from_dns.is_empty() {
+        host_name.trim()
+    } else {
+        from_dns
+    };
+    (!name.is_empty()).then(|| name.to_lowercase())
+}
+
+/// What to connect to: the MagicDNS FQDN (stable across IP churn, and what Tailscale SSH
+/// expects), falling back to the peer's Tailscale IP — IPv4 first — when MagicDNS is off for
+/// the tailnet or the peer has no DNS name.
+fn peer_hostname(dns: &str, ips: &[String], magic_dns_enabled: bool) -> Option<String> {
+    if magic_dns_enabled && !dns.is_empty() {
+        return Some(dns.to_string());
+    }
+    ips.iter()
+        .find(|ip| ip.trim().parse::<Ipv4Addr>().is_ok())
+        .or_else(|| ips.first())
+        .map(|ip| ip.trim().to_string())
+        .filter(|ip| !ip.is_empty())
+        .or_else(|| (!dns.is_empty()).then(|| dns.to_string()))
+}
+
+/// ACL tags arrive as `tag:server`; sshelf tags are bare words. Peers without tags get an
+/// empty list — no marker tag is invented.
+fn peer_tags(tags: &[String]) -> Vec<String> {
+    tags.iter()
+        .map(|t| t.strip_prefix("tag:").unwrap_or(t).trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect()
+}
+
+fn first_label(fqdn: &str) -> &str {
+    fqdn.split('.').next().unwrap_or("")
+}
+
+/// Locate the user's `tailscale` CLI: `$SSHELF_TAILSCALE_BIN`, then `PATH`, then (on macOS)
+/// the app bundle. Errors name all three so the user knows what to fix.
+pub fn resolve_binary() -> Result<PathBuf> {
+    let env_bin = std::env::var_os(BIN_ENV).filter(|v| !v.is_empty());
+    let path_var = std::env::var_os("PATH");
+    resolve_in(
+        env_bin.as_deref().map(Path::new),
+        path_var.as_deref(),
+        cfg!(target_os = "macos").then_some(Path::new(MACOS_APP_BIN)),
+    )
+}
+
+/// The resolution rule over explicit inputs, so tests never touch the process environment.
+fn resolve_in(
+    env_bin: Option<&Path>,
+    path_var: Option<&OsStr>,
+    app_bin: Option<&Path>,
+) -> Result<PathBuf> {
+    if let Some(bin) = env_bin {
+        if !is_executable(bin) {
+            bail!(
+                "${BIN_ENV} is set to {} — that isn't an executable file",
+                bin.display()
+            );
+        }
+        return Ok(bin.to_path_buf());
+    }
+    if let Some(found) = path_var.and_then(|p| find_on_path(p, "tailscale")) {
+        return Ok(found);
+    }
+    if let Some(app) = app_bin.filter(|p| is_executable(p)) {
+        return Ok(app.to_path_buf());
+    }
+    bail!(
+        "could not find the `tailscale` CLI. sshelf looks in three places:\n  \
+         1. ${BIN_ENV} (not set)\n  \
+         2. `tailscale` on your PATH\n  \
+         3. {MACOS_APP_BIN} (the macOS app, which doesn't add its CLI to PATH)\n\
+         Install the Tailscale CLI, or point sshelf at it with \
+         {BIN_ENV}=/path/to/tailscale."
+    )
+}
+
+fn find_on_path(path_var: &OsStr, name: &str) -> Option<PathBuf> {
+    std::env::split_paths(path_var)
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .map(|dir| dir.join(name))
+        .find(|candidate| is_executable(candidate))
+}
+
+fn is_executable(path: &Path) -> bool {
+    let Ok(meta) = path.metadata() else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+/// Run the user's `tailscale status --json` and return its stdout. The only process this
+/// feature spawns, and only from `sshelf import --tailscale`.
+fn capture_status(bin: &Path) -> Result<String> {
+    let out = Command::new(bin)
+        .args(["status", "--json"])
+        .output()
+        .with_context(|| format!("running `{} status --json`", bin.display()))?;
+    let stdout = String::from_utf8(out.stdout)
+        .with_context(|| format!("`{} status --json` returned invalid UTF-8", bin.display()))?;
+    // Some states exit non-zero while still reporting a usable status document, so the exit
+    // code only matters when there's nothing to parse.
+    if stdout.trim().is_empty() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let detail = match stderr.trim() {
+            "" => String::new(),
+            msg => format!(": {msg}"),
+        };
+        bail!(
+            "`{} status --json` produced no output ({}){detail}",
+            bin.display(),
+            out.status
+        );
+    }
+    Ok(stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::import::new_hosts;
+    use crate::model::AuthMethod;
+
+    /// Shaped after a real `tailscale status --json` (fields sshelf reads, plus a couple of
+    /// neighbours for realism): a tagged peer, an untagged one, an offline one, an expired
+    /// one, a Mullvad exit node, and a shared-in node from another tailnet.
+    const TAILNET: &str = r#"{
+  "Version": "1.98.9-t4fb758c39-g200941d74",
+  "BackendState": "Running",
+  "MagicDNSSuffix": "tail4f9a2.ts.net",
+  "CurrentTailnet": {
+    "Name": "homelab.example.com",
+    "MagicDNSSuffix": "tail4f9a2.ts.net",
+    "MagicDNSEnabled": true
+  },
+  "Self": {
+    "HostName": "workstation",
+    "DNSName": "workstation.tail4f9a2.ts.net.",
+    "TailscaleIPs": ["100.64.0.1"],
+    "Online": true
+  },
+  "Peer": {
+    "nodekey:1111111111111111111111111111111111111111111111111111111111111111": {
+      "ID": "n1",
+      "HostName": "nas",
+      "DNSName": "nas.tail4f9a2.ts.net.",
+      "OS": "linux",
+      "TailscaleIPs": ["100.64.0.11", "fd7a:115c:a1e0::1101"],
+      "Tags": ["tag:server", "tag:storage"],
+      "Online": true,
+      "Active": true
+    },
+    "nodekey:2222222222222222222222222222222222222222222222222222222222222222": {
+      "ID": "n2",
+      "HostName": "raeds-macbook-pro",
+      "DNSName": "raeds-macbook-pro.tail4f9a2.ts.net.",
+      "OS": "macOS",
+      "TailscaleIPs": ["100.64.0.12", "fd7a:115c:a1e0::1202"],
+      "Online": true,
+      "Active": false
+    },
+    "nodekey:3333333333333333333333333333333333333333333333333333333333333333": {
+      "ID": "n3",
+      "HostName": "Old-Laptop",
+      "DNSName": "old-laptop.tail4f9a2.ts.net.",
+      "OS": "windows",
+      "TailscaleIPs": ["100.64.0.13"],
+      "Online": false,
+      "Active": false
+    },
+    "nodekey:4444444444444444444444444444444444444444444444444444444444444444": {
+      "ID": "n4",
+      "HostName": "retired-pi",
+      "DNSName": "retired-pi.tail4f9a2.ts.net.",
+      "OS": "linux",
+      "TailscaleIPs": ["100.64.0.14"],
+      "Expired": true,
+      "Online": false
+    },
+    "nodekey:5555555555555555555555555555555555555555555555555555555555555555": {
+      "ID": "n5",
+      "HostName": "de-ber-wg-101",
+      "DNSName": "de-ber-wg-101.mullvad.ts.net.",
+      "OS": "linux",
+      "TailscaleIPs": ["100.96.0.5"],
+      "Tags": ["tag:mullvad-exit-node"],
+      "ExitNodeOption": true,
+      "Online": true
+    },
+    "nodekey:6666666666666666666666666666666666666666666666666666666666666666": {
+      "ID": "n6",
+      "HostName": "buildbox",
+      "DNSName": "buildbox.tailc0ffee.ts.net.",
+      "OS": "linux",
+      "TailscaleIPs": ["100.72.0.9"],
+      "Online": true
+    }
+  },
+  "User": null,
+  "ClientVersion": null
+}"#;
+
+    fn find<'a>(r: &'a ImportResult, name: &str) -> &'a Host {
+        r.hosts
+            .iter()
+            .find(|h| h.name == name)
+            .unwrap_or_else(|| panic!("expected a host named {name:?}"))
+    }
+
+    #[test]
+    fn maps_eligible_peers_and_their_fields() {
+        let r = parse_status_json(TAILNET).unwrap();
+        let names: Vec<&str> = r.hosts.iter().map(|h| h.name.as_str()).collect();
+        assert_eq!(names, ["nas", "old-laptop", "raeds-macbook-pro"]);
+
+        let nas = find(&r, "nas");
+        // MagicDNS FQDN, trailing dot trimmed — stable across IP churn.
+        assert_eq!(nas.hostname, "nas.tail4f9a2.ts.net");
+        assert_eq!(nas.tags, vec!["server".to_string(), "storage".to_string()]);
+        assert_eq!(nas.site.as_deref(), Some("homelab.example.com"));
+        assert_eq!(nas.auth, AuthMethod::Agent);
+        assert_eq!(nas.user, None);
+        assert_eq!(nas.port, None);
+        assert!(nas.jump_hosts.is_empty() && nas.extra_args.is_none());
+        assert!(!nas.id.is_empty());
+
+        // An untagged peer gets no tags — no marker tag is invented.
+        assert!(find(&r, "raeds-macbook-pro").tags.is_empty());
+        // Offline is transient, so an asleep machine is still imported; the name is lowercased.
+        assert_eq!(
+            find(&r, "old-laptop").hostname,
+            "old-laptop.tail4f9a2.ts.net"
+        );
+    }
+
+    #[test]
+    fn excludes_expired_and_foreign_peers_with_one_warning() {
+        let r = parse_status_json(TAILNET).unwrap();
+        for skipped in ["retired-pi", "de-ber-wg-101", "buildbox"] {
+            assert!(
+                !r.hosts.iter().any(|h| h.name == skipped),
+                "{skipped} should not be imported"
+            );
+        }
+        assert_eq!(r.warnings.len(), 1, "{:?}", r.warnings);
+        let w = &r.warnings[0];
+        assert!(w.starts_with("3 peer(s) excluded"), "{w}");
+        assert!(w.contains("2 outside this tailnet"), "{w}");
+        assert!(w.contains("1 with an expired node key"), "{w}");
+    }
+
+    #[test]
+    fn self_is_never_imported() {
+        let r = parse_status_json(TAILNET).unwrap();
+        assert!(!r.hosts.iter().any(|h| h.name == "workstation"));
+    }
+
+    #[test]
+    fn magic_dns_disabled_falls_back_to_the_ipv4_address() {
+        let json = r#"{
+          "BackendState": "Running",
+          "CurrentTailnet": {
+            "Name": "tail4f9a2.ts.net",
+            "MagicDNSSuffix": "tail4f9a2.ts.net",
+            "MagicDNSEnabled": false
+          },
+          "Peer": {
+            "nodekey:aa": {
+              "HostName": "nas",
+              "DNSName": "nas.tail4f9a2.ts.net.",
+              "TailscaleIPs": ["fd7a:115c:a1e0::1101", "100.64.0.11"]
+            },
+            "nodekey:bb": {
+              "HostName": "v6only",
+              "DNSName": "v6only.tail4f9a2.ts.net.",
+              "TailscaleIPs": ["fd7a:115c:a1e0::1202"]
+            }
+          }
+        }"#;
+        let r = parse_status_json(json).unwrap();
+        // The name still comes from MagicDNS; only the address falls back — IPv4 first,
+        // whatever the order in TailscaleIPs, and the first entry when there is no IPv4.
+        assert_eq!(find(&r, "nas").hostname, "100.64.0.11");
+        assert_eq!(find(&r, "v6only").hostname, "fd7a:115c:a1e0::1202");
+    }
+
+    #[test]
+    fn peer_without_a_dns_name_uses_hostname_and_ip() {
+        let json = r#"{
+          "BackendState": "Running",
+          "CurrentTailnet": {
+            "Name": "tail4f9a2.ts.net",
+            "MagicDNSSuffix": "tail4f9a2.ts.net",
+            "MagicDNSEnabled": true
+          },
+          "Peer": {
+            "nodekey:aa": {
+              "HostName": "Legacy-Box",
+              "DNSName": "",
+              "TailscaleIPs": ["100.64.0.21"]
+            },
+            "nodekey:bb": { "HostName": "", "DNSName": "", "TailscaleIPs": null }
+          }
+        }"#;
+        let r = parse_status_json(json).unwrap();
+        assert_eq!(r.hosts.len(), 1);
+        assert_eq!(r.hosts[0].name, "legacy-box");
+        assert_eq!(r.hosts[0].hostname, "100.64.0.21");
+        // The nameless, address-less peer is counted, not silently dropped.
+        assert!(
+            r.warnings[0].contains("1 with no usable name or address"),
+            "{:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn colliding_names_keep_the_first_and_warn() {
+        // Same first label under two sub-domains of the tailnet: only one host survives.
+        let json = r#"{
+          "BackendState": "Running",
+          "CurrentTailnet": {
+            "Name": "tail4f9a2.ts.net",
+            "MagicDNSSuffix": "tail4f9a2.ts.net",
+            "MagicDNSEnabled": true
+          },
+          "Peer": {
+            "nodekey:aa": { "HostName": "nas", "DNSName": "nas.tail4f9a2.ts.net." },
+            "nodekey:bb": { "HostName": "nas", "DNSName": "nas.eu.tail4f9a2.ts.net." }
+          }
+        }"#;
+        let r = parse_status_json(json).unwrap();
+        assert_eq!(r.hosts.len(), 1);
+        // Peers iterate in public-key order, so the first key wins deterministically.
+        assert_eq!(r.hosts[0].hostname, "nas.tail4f9a2.ts.net");
+        assert!(
+            r.warnings.iter().any(|w| w.contains("kept the first")),
+            "{:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn tailnet_name_falls_back_to_the_suffixs_first_label() {
+        let json = r#"{
+          "BackendState": "Running",
+          "CurrentTailnet": { "Name": "", "MagicDNSSuffix": "tail4f9a2.ts.net", "MagicDNSEnabled": true },
+          "Peer": { "nodekey:aa": { "HostName": "nas", "DNSName": "nas.tail4f9a2.ts.net." } }
+        }"#;
+        let r = parse_status_json(json).unwrap();
+        assert_eq!(r.hosts[0].site.as_deref(), Some("tail4f9a2"));
+    }
+
+    #[test]
+    fn a_backend_that_isnt_running_says_how_to_fix_it() {
+        for state in ["Stopped", "NeedsLogin", "NoState"] {
+            let json = format!("{{\"BackendState\": \"{state}\", \"Peer\": null}}");
+            let err = parse_status_json(&json).unwrap_err().to_string();
+            assert!(err.contains(state), "{err}");
+            assert!(err.contains("tailscale up"), "{err}");
+        }
+    }
+
+    #[test]
+    fn garbage_json_blames_the_tailscale_version() {
+        let err = parse_status_json("not json at all").unwrap_err();
+        let text = format!("{err:#}");
+        assert!(text.contains("tailscale status --json"), "{text}");
+        assert!(text.contains("tailscale version"), "{text}");
+
+        // Valid JSON of the wrong shape fails the same way.
+        assert!(parse_status_json(r#"{"BackendState": 7}"#).is_err());
+    }
+
+    #[test]
+    fn a_running_tailnet_with_no_suffix_is_an_error() {
+        let json = r#"{"BackendState": "Running", "CurrentTailnet": null, "Peer": null}"#;
+        let err = parse_status_json(json).unwrap_err().to_string();
+        assert!(err.contains("no tailnet"), "{err}");
+    }
+
+    #[test]
+    fn dedupe_against_existing_hosts_is_case_insensitive() {
+        let r = parse_status_json(TAILNET).unwrap();
+        let existing = vec![Host::new("NAS", "10.0.0.1")];
+        let fresh = new_hosts(&r.hosts, &existing);
+        assert!(!fresh.iter().any(|h| h.name.eq_ignore_ascii_case("nas")));
+        assert_eq!(fresh.len(), 2);
+        // Re-importing the same tailnet converges to nothing new.
+        assert!(new_hosts(&r.hosts, &r.hosts).is_empty());
+    }
+
+    #[test]
+    fn tags_lose_their_tag_prefix() {
+        assert_eq!(
+            peer_tags(&["tag:server".into(), "plain".into(), "tag:".into()]),
+            vec!["server".to_string(), "plain".to_string()]
+        );
+        assert!(peer_tags(&[]).is_empty());
+    }
+
+    // --- binary resolution -------------------------------------------------------------
+
+    /// A directory with an executable `tailscale` stub in it.
+    fn stub_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("sshelf-ts-{}", ulid::Ulid::new()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bin = dir.join("tailscale");
+        std::fs::write(&bin, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn the_env_override_wins_over_path() {
+        let dir = stub_dir();
+        let explicit = dir.join("tailscale");
+        let found = resolve_in(Some(&explicit), Some(OsStr::new("/nowhere")), None).unwrap();
+        assert_eq!(found, explicit);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_bogus_env_override_is_reported_as_such() {
+        let err = resolve_in(Some(Path::new("/nope/tailscale")), None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains(BIN_ENV), "{err}");
+        assert!(err.contains("/nope/tailscale"), "{err}");
+    }
+
+    #[test]
+    fn path_is_searched_then_the_macos_app_bundle() {
+        let dir = stub_dir();
+        let found = resolve_in(None, Some(dir.as_os_str()), None).unwrap();
+        assert_eq!(found, dir.join("tailscale"));
+
+        // Nothing on PATH → the app-bundle fallback, when it exists.
+        let app = dir.join("tailscale");
+        let found = resolve_in(None, Some(OsStr::new("/nowhere")), Some(&app)).unwrap();
+        assert_eq!(found, app);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn not_found_anywhere_names_all_three_options() {
+        let err = resolve_in(None, Some(OsStr::new("/nowhere")), None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains(BIN_ENV), "{err}");
+        assert!(err.contains("PATH"), "{err}");
+        assert!(err.contains(MACOS_APP_BIN), "{err}");
+    }
+}


### PR DESCRIPTION
Fills the host database from the inventory a homelab/small-fleet user already curates: one
command turns a whole tailnet into fuzzy-searchable sshelf hosts. Headline feature for v0.11.0.

## What it does

`sshelf import --tailscale` runs the user's **own** `tailscale status --json` and maps every
eligible peer:

| sshelf field | From the peer |
|---|---|
| `name` | first label of the MagicDNS name, lowercased |
| `hostname` | the MagicDNS FQDN (Tailscale IP, IPv4 first, when MagicDNS is off for the tailnet) |
| `site` | the tailnet — matched case-insensitively, created bare when new |
| `tags` | ACL tags minus the `tag:` prefix |
| `auth` | `agent` |

Eligibility is one rule — the peer's `DNSName` must sit under the tailnet's own
`MagicDNSSuffix` — which excludes Mullvad exit nodes and shared-in nodes without special
cases. Expired peers are skipped; **offline peers are not** (an asleep laptop is still a host).

## Invariants held

- **No network of our own.** The CLI runs only from this subcommand — never at startup, on
  save, on a timer, or from the TUI. No API key, no HTTP client, no tokio.
- **Add-only.** Existing hosts and sites are matched case-insensitively and never updated or
  deleted, so a re-run adds 0 and leaves `hosts.toml` byte-identical. Nothing tailscale-specific
  (node IDs, keys) is stored; `format_version` unchanged.
- **Nothing under `~/.ssh`** is read or written, as ever.
- **No new dependencies** (`serde_json` + `anyhow` were already in the tree).

Binary resolution: `$SSHELF_TAILSCALE_BIN` → `PATH` → `/Applications/Tailscale.app/Contents/MacOS/Tailscale`
(the macOS app doesn't add its CLI to `PATH`), with an error naming all three.

Both import modes now share one tail — dedupe, site creation, save, export refresh — so the
D-023 ssh_config fragment refreshes after a tailnet import exactly as after an ssh-config one.

## Verification

18 new tests (213 pass), `clippy --all-targets -D warnings` clean, `fmt --check` clean,
`cargo check` on MSRV 1.88 clean. End-to-end against a stub `tailscale` fed the test fixture
with an isolated config dir: hosts + site land correctly, counts match, a second run adds 0
with an identical file, `--dry-run` writes nothing, an existing differently-cased host/site is
reused rather than duplicated, and a pre-created export fragment refreshed (without one,
nothing was created). Each failure mode gives one message and exit 1 — backend not running,
unparseable JSON, bad `$SSHELF_TAILSCALE_BIN` — and the macOS app-bundle fallback was exercised
against the real client. **Live tailnet run:** on a real 6-peer tailnet with MagicDNS
*disabled* (so the IPv4 fallback took the real path), the binary resolved itself from the macOS
app bundle and imported the 2 peers with valid node keys, excluding 4 expired ones and `Self`;
a re-run added 0, and `list --json` / `print-command` gave usable ssh commands.

Docs synced per the docs-in-sync rule: `import.md` (now "Importing hosts"), CLI reference, FAQ,
structure, architecture, index, README, **D-024**, progress log, CHANGELOG — which also
collapses a duplicated `0.10.0` heading and link line.
